### PR TITLE
Mobile install prompt: show on touch devices in controller mode

### DIFF
--- a/client/src/components/InstallPrompt.tsx
+++ b/client/src/components/InstallPrompt.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from "react";
+import { Download, Menu, Share } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DialogOverlay } from "@/components/ui/dialog-overlay";
+import { useIsTouchDevice } from "@/hooks/useIsMobile";
+import { useIsStandalone } from "@/hooks/useIsStandalone";
+import { lsGetString, lsSetString, STORAGE_KEYS } from "@/lib/storage";
+
+// Chrome/Edge's beforeinstallprompt event — not part of the DOM lib.
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+declare global {
+  interface WindowEventMap {
+    beforeinstallprompt: BeforeInstallPromptEvent;
+    appinstalled: Event;
+  }
+}
+
+function isIOS(): boolean {
+  const ua = navigator.userAgent;
+  return (
+    /iPhone|iPad|iPod/.test(ua) ||
+    // iPadOS reports as a Mac (userAgent is desktop) but has touch points.
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+  );
+}
+
+// Add-to-home-screen prompt, shown on touch devices while someone is presenting
+// (controller mode) rather than on the landing page — that's the moment running
+// installed actually matters, and the app already behaves differently there.
+// Uses the platform's install flow (beforeinstallprompt -> prompt()) where the
+// browser offers it, and falls back to step-by-step instructions where it
+// doesn't (iOS Safari). Never shown on desktop, never when the app is already
+// running installed, and never more than once per device.
+export function InstallPrompt() {
+  // Touch-first screen (phone or tablet, any orientation) — width alone would
+  // miss an iPad in landscape.
+  const isMobile = useIsTouchDevice();
+  const standalone = useIsStandalone();
+  const [seen, setSeen] = useState(
+    () => lsGetString(STORAGE_KEYS.installPromptSeen) === "true"
+  );
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    // Capture the browser's prompt while the dialog might be open. Never fires on
+    // iOS; on Chrome/Android it can arrive a beat after first paint, so keep
+    // listening rather than only checking state once.
+    const onInstallable = (e: BeforeInstallPromptEvent) => {
+      e.preventDefault();
+      setDeferred(e);
+    };
+    // Install completed (via any route): never offer it again.
+    const onInstalled = () => {
+      lsSetString(STORAGE_KEYS.installPromptSeen, "true");
+      setSeen(true);
+    };
+    window.addEventListener("beforeinstallprompt", onInstallable);
+    window.addEventListener("appinstalled", onInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onInstallable);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, []);
+
+  if (!isMobile || standalone || seen) return null;
+
+  const dismiss = () => {
+    lsSetString(STORAGE_KEYS.installPromptSeen, "true");
+    setSeen(true);
+  };
+
+  const install = async () => {
+    if (!deferred) return; // fallback is instructions-only
+    await deferred.prompt();
+    // Accepted or declined, the browser dialog is the answer — don't re-ask.
+    dismiss();
+  };
+
+  return (
+    <DialogOverlay onClose={dismiss} maxWidth="max-w-xs">
+      <div className="flex flex-col items-center gap-3 text-center">
+        {deferred ? (
+          <>
+            <Download className="text-muted-foreground" size={28} />
+            <h2 className="text-lg font-semibold">Install Presio</h2>
+            <p className="text-sm text-muted-foreground">
+              Add Presio to this device for a full-screen, app-like way to
+              upload, control and present slides.
+            </p>
+            <Button className="w-full" onClick={install}>
+              Install
+            </Button>
+          </>
+        ) : (
+          <>
+            <Share className="text-muted-foreground" size={28} />
+            <h2 className="text-lg font-semibold">Add Presio to your Home Screen</h2>
+            {isIOS() ? (
+              <p className="text-sm text-muted-foreground">
+                Tap the Share button{" "}
+                <Share size={13} className="inline -mx-0.5 text-foreground" />,
+                then choose{" "}
+                <span className="font-medium text-foreground">
+                  "Add to Home Screen"
+                </span>{" "}
+                to run Presio like an app.
+              </p>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Open your browser's menu{" "}
+                <Menu size={13} className="inline -mx-0.5 text-foreground" /> and
+                choose{" "}
+                <span className="font-medium text-foreground">
+                  "Add to Home Screen"
+                </span>{" "}
+                or "Install app" to run Presio like an app.
+              </p>
+            )}
+            <Button className="w-full" variant="outline" onClick={dismiss}>
+              Got it
+            </Button>
+          </>
+        )}
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/client/src/components/MobileNotice.tsx
+++ b/client/src/components/MobileNotice.tsx
@@ -2,15 +2,17 @@ import { useState } from "react";
 import { Smartphone } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DialogOverlay } from "@/components/ui/dialog-overlay";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useIsTouchDevice } from "@/hooks/useIsMobile";
 import { lsGetString, lsSetString, STORAGE_KEYS } from "@/lib/storage";
 
-// First-run notice for phones/tablets: Presio's authoring surface is built for
-// desktop, so we set expectations up front and point out the useful mobile role
-// (joining as a viewer, or acting as a remote for a presentation on another
-// screen). Shown once, then remembered.
+// First-run notice for touch devices (phones/tablets, any orientation): Presio's
+// authoring surface is built for desktop, so we set expectations up front and
+// point out the useful mobile role (joining as a viewer, or acting as a remote
+// for a presentation on another screen). Shown once, then remembered.
 export function MobileNotice() {
-  const isMobile = useIsMobile();
+  // Touch-first screen, not width — an iPad in landscape exceeds the mobile
+  // width breakpoint but is every bit a touchscreen.
+  const isMobile = useIsTouchDevice();
   const [open, setOpen] = useState(
     () => lsGetString(STORAGE_KEYS.mobileNoticeSeen) !== "true"
   );

--- a/client/src/hooks/useIsMobile.ts
+++ b/client/src/hooks/useIsMobile.ts
@@ -30,3 +30,27 @@ export function useIsMobile(breakpoint = 768) {
 
   return isMobile && !forceDesktop;
 }
+
+// Touch-device detection for the first-visit prompts. Width alone misses
+// tablets: an iPad in landscape is 1024px wide (1366px on a Pro), well past
+// the 768px mobile breakpoint. The primary pointer being coarse (finger/stylus)
+// is the reliable signal that the screen is touch-first, holds in any
+// orientation, and stays false on desktop touch-laptops whose primary input is
+// a mouse/trackpad. Respects the same ?desktop=1 override as useIsMobile.
+export function isTouchDevice(): boolean {
+  if (forceDesktop) return false;
+  return window.matchMedia("(pointer: coarse)").matches;
+}
+
+export function useIsTouchDevice(): boolean {
+  const [isTouch, setIsTouch] = useState(isTouchDevice);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(pointer: coarse)");
+    const onChange = () => setIsTouch(isTouchDevice());
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  return isTouch;
+}

--- a/client/src/hooks/useIsStandalone.ts
+++ b/client/src/hooks/useIsStandalone.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+// True when the app is running from an installed PWA rather than a browser tab.
+// The manifest sets display: standalone, so installed launches report
+// `display-mode: standalone`; older iOS builds exposed it as navigator.standalone.
+// Checked via media query (with a change listener) plus the legacy property.
+export function isStandalone(): boolean {
+  try {
+    return (
+      window.matchMedia("(display-mode: standalone)").matches ||
+      (navigator as Navigator & { standalone?: boolean }).standalone === true
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function useIsStandalone(): boolean {
+  const [standalone, setStandalone] = useState(isStandalone);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(display-mode: standalone)");
+    const update = () => setStandalone(isStandalone());
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+
+  return standalone;
+}

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -18,6 +18,9 @@ export const STORAGE_KEYS = {
   controllerOnboarded: "presio_controller_onboarded",
   // Whether the mobile "best on desktop" notice has been dismissed.
   mobileNoticeSeen: "presio_mobile_notice_seen",
+  // Whether the add-to-home-screen prompt has been seen/actioned. Shown on
+  // touch devices while presenting, never on the landing page.
+  installPromptSeen: "presio_install_prompt_seen",
   // Hidden ?desktop=1 escape hatch: force the desktop layout on mobile.
   forceDesktop: "presio_force_desktop",
   // Last-used drawing color/width for the annotation tools.

--- a/client/src/pages/ControllerView.tsx
+++ b/client/src/pages/ControllerView.tsx
@@ -12,6 +12,7 @@ import { LoginDialog } from "@/components/LoginDialog";
 import { AccountControl } from "@/components/AccountControl";
 import { ControllerOnboarding } from "@/components/ControllerOnboarding";
 import { NewsletterDialog } from "@/components/NewsletterDialog";
+import { InstallPrompt } from "@/components/InstallPrompt";
 import { useNewsletterPrompt } from "@/lib/useNewsletterPrompt";
 import { DownloadButton } from "@/components/DownloadButton";
 import { hasCompletedControllerOnboarding } from "@/lib/onboarding";
@@ -732,6 +733,10 @@ export function ControllerView({
       )}
 
       {newsletter.open && <NewsletterDialog onClose={newsletter.close} />}
+
+      {/* Add-to-home-screen — touch devices using this phone/tablet as the
+          presenter's controller. Self-gates to touch + not-installed + once. */}
+      <InstallPrompt />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Completes the remaining acceptance criteria of [issue #11](https://github.com/benedict-armstrong/presio/issues/11) (first-visit mobile prompts):
- Adds the add-to-home-screen prompt for touch devices.
- Shows it only while the phone/tablet is the presenter's controller — the moment running installed actually matters — rather than on the landing page.
- Uses the platform install flow (`beforeinstallprompt` → `prompt()`) where available; falls back to step-by-step "Share → Add to Home Screen" instructions on iOS/iPadOS (which has no install API).
- Never appears on desktop, never when already running installed (`display-mode: standalone`), never more than once per device.

The existing "Best on desktop" notice stays on the Home page.

## Changes

- **New** `client/src/components/InstallPrompt.tsx` — add-to-home-screen dialog (install sheet or instructions), self-gated to touch, not-installed, not-yet-seen.
- **New** `client/src/hooks/useIsStandalone.ts` — detects installed PWA (media query + legacy `navigator.standalone`).
- **`client/src/hooks/useIsMobile.ts`** — adds `useIsTouchDevice` (`pointer: coarse`) so prompts reach tablets like an iPad in landscape (1024–1366px), which the 768px mobile breakpoint misses.
- **`client/src/pages/ControllerView.tsx`** — mounts `<InstallPrompt />` with the other controller dialogs.
- **`client/src/pages/Home.tsx`**, **`client/src/components/MobileNotice.tsx`** — removed the install prompt from the landing page; dropped the now-unused notice-sequencing event (and deleted `lib/prompts.ts`).

## Verification

- `tsc -b`, `eslint`, and the 30 test cases pass.
- Manual check on iPad (landscape + portrait): notice appears on Home, install-prompt instructions appear after entering controller mode, hidden after install or once dismissed.

## Notes

iOS/iPadOS has no `beforeinstallprompt` — the actual install sheet can't be triggered programmatically, so iOS users get instructions instead.