### PR TITLE
Derive slide count from the loaded document, not the frozen database row

### DIFF
--- a/client/src/pages/Presentation.tsx
+++ b/client/src/pages/Presentation.tsx
@@ -176,6 +176,28 @@ export default function Presentation() {
     };
   }, [id]);
 
+  // The loaded document decides the page count: URL-backed decks re-fetch
+  // their PDF on every load, so a republished file can change the page count
+  // under a value stored at creation time. Adopt the document's count, pull
+  // the current slide back into range, and refresh whatever stored count
+  // remains (IndexedDB record / session row) so every device agrees.
+  useEffect(() => {
+    if (!deckInfo) return;
+    const docTotal = deckInfo.totalSlides;
+    if (totalSlides === docTotal) return;
+    setTotalSlides(docTotal);
+    setCurrentSlide((slide) => Math.min(Math.max(slide, 1), docTotal));
+    if (local) {
+      idbGet(id!).then((rec) => {
+        if (rec && rec.totalSlides !== docTotal) idbPut({ ...rec, totalSlides: docTotal });
+      }).catch(() => { /* best effort */ });
+    } else if (role === "controller") {
+      // Only the controller can correct the stored row; viewers already show
+      // the document-derived count either way.
+      socket.emit("total_slides_change", { totalSlides: docTotal });
+    }
+  }, [deckInfo, totalSlides, local, role, id]);
+
   useEffect(() => {
     if (!filename) return;
     const suffix = role === "controller" ? "Controller" : "Viewer";
@@ -316,6 +338,13 @@ export default function Presentation() {
       setCurrentSlide(slideNumber);
     });
 
+    // The controller corrected the session's page count against the document
+    // it loaded; follow suit and stay in range.
+    socket.on("total_slides_update", ({ totalSlides }: { totalSlides: number }) => {
+      setTotalSlides(totalSlides);
+      setCurrentSlide((slide) => Math.min(Math.max(slide, 1), totalSlides));
+    });
+
     socket.on("sync_all", () => {
       setViewerSlide(null);
     });
@@ -389,6 +418,7 @@ export default function Presentation() {
       socket.off("connect", join);
       socket.off("session_state");
       socket.off("slide_update");
+      socket.off("total_slides_update");
       socket.off("sync_all");
       socket.off("blank_update");
       socket.off("code_update");

--- a/server/socket.ts
+++ b/server/socket.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { safeEqual } from "./auth.js";
 import {
   isValidSlideNumber,
+  isValidTotalSlides,
   sanitizeLaserPoint,
   sanitizeStroke,
   sanitizeAnnotations,
@@ -186,6 +187,18 @@ export function registerSocketHandlers(
 
     socket.on("sync_all", controllerOnly(socket, (sessionId) => {
       io.to(sessionId).emit("sync_all");
+    }));
+
+    // The controller derives the deck's page count from the PDF it actually
+    // loaded. A URL-backed deck is re-fetched on every load, so republishing
+    // the file with a different page count leaves the stored row stale —
+    // correct it here so slide validation and later joins match the document
+    // on screen.
+    socket.on("total_slides_change", controllerOnly(socket, async (sessionId, { totalSlides }: { totalSlides: number }) => {
+      if (!isValidTotalSlides(totalSlides)) return;
+      socket.data.totalSlides = totalSlides;
+      io.to(sessionId).emit("total_slides_update", { totalSlides });
+      await supabase.from("sessions").update({ total_slides: totalSlides }).eq("id", sessionId);
     }));
 
     socket.on("blank_toggle", controllerOnly(socket, (sessionId) => {


### PR DESCRIPTION
Closes #7

## Summary

A presentation's page count was frozen into the session row at creation time and read back from there, so republishing a URL-backed PDF with a different page count desynced navigation: the controller couldn't reach new pages (or could page past removed ones), even though every view already rendered from `deck.totalSlides`, which is derived from the loaded pdfjs document (`loadDeckInfo`). The frozen value leaked through three places:

- `Presentation.tsx`'s `totalSlides` state seeded from the DB row / IndexedDB record — used by the `goTo`/`viewerGoTo` range guards and the BroadcastChannel state sync
- server-side slide validation, bounded by `socket.data.totalSlides` read from the row at join time
- later joins / other devices, which receive the stored count in `session_state`

Changes:

- **`client/src/pages/Presentation.tsx`** — once the document is parsed (`deckInfo`), adopt its page count as the session's count, clamp `currentSlide` into range, and refresh whatever stored count remains: the IndexedDB record for local presentations; for synced ones the controller emits a new `total_slides_change` socket event. A `total_slides_update` listener keeps connected clients (and their clamps) in agreement.
- **`server/socket.ts`** — new controller-only `total_slides_change` handler: validates with `isValidTotalSlides`, re-bounds the controller's own validation limit, broadcasts `total_slides_update` to the room, and persists `total_slides` on the session row so subsequent joins agree.

## Acceptance criteria

- [x] **Slide count derived from the loaded document** — all views already used `deck.totalSlides` (= `pdf.numPages`); now the nav guards, BroadcastChannel sync, socket validation bound, and stored row follow it too.
- [x] **Reload after remote PDF gains pages exposes them** — client adopts the larger document count (thumbnails, next-slide card, last-slide shortcut, free viewer navigation all extend); smoke test shows `slide_change` into the gained range is accepted and persisted once corrected.
- [x] **Reload after pages are lost clamps into range** — `currentSlide` is clamped to the document count on load and again whenever a correction broadcast arrives; past-end navigation is rejected by both client guard and server validation.
- [x] **Stored count refreshed so multi-device sessions agree** — controller persists the corrected count to the session row (verified via API) and local sessions rewrite their IndexedDB record.
- [x] **Local and synced presentations both behave correctly** — local decks reconcile against their own bytes (idb refresh branch); synced path exercised end-to-end.

## Verification

- `cd client && npm run build` — passes (tsc -b + vite build)
- `cd client && npm run lint` — passes
- `cd client && npm test` — 30 passed
- `cd server && npm test` — 27 passed
- `tsc --noEmit` on server — clean
- Live smoke test against `PRESIO_MODE=local` server: claimed a session with a 5-page PDF at slide 4, then as controller issued `total_slides_change` to 8 → echo + viewer broadcast received, row updated, later join saw 8, `slide_change` to slide 7 accepted/persisted; shrink to 2 → persisted, `slide_change` past the new end rejected; non-controller and malformed corrections (0, `"9"`) ignored. All assertions passed.

## Human follow-ups

- No browser-level E2E was run (playwright suite excluded per instructions): worth a manual pass of create-from-URL → republish with more/fewer pages → reload controller & viewer, confirming thumbnails/clamp on screen.
- Transient window only: if a *viewer* reloads onto a shrunken deck before the controller does, the still-open old controller can briefly push slide numbers beyond the new document until it reloads/corrects; rendering recovers on the next in-range change. Inherent to republishing under a live session.