### PR TITLE
Add content hash to upload analytics event

### DIFF
--- a/client/src/lib/analytics.ts
+++ b/client/src/lib/analytics.ts
@@ -18,3 +18,13 @@ export function track(name: string, data?: Record<string, unknown>) {
     // Swallow: a failed beacon is never worth surfacing to a presenter.
   }
 }
+
+// SHA-256 of raw bytes, hex-encoded. Lets events fingerprint content (e.g.
+// tell a recompiled deck apart from an identical re-upload) without any file
+// contents leaving the browser — only the digest itself is ever sent.
+export async function sha256Hex(data: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import { MobileNotice } from "@/components/MobileNotice";
 import { CodeBlock } from "@/components/CodeBlock";
 import { idbPut } from "@/lib/localStore";
 import { setSessionAuth } from "@/lib/utils";
+import { track, sha256Hex } from "@/lib/analytics";
 import { loadExternalPdfMeta, createExternalSession } from "@/lib/externalSession";
 import { supabase } from "@/lib/supabaseClient";
 import "@/lib/pdf"; // ensure pdf.js worker is configured
@@ -253,6 +254,17 @@ export default function Home() {
         // Snapshot before getDocument(), which transfers the buffer to the
         // pdf.js worker and leaves it detached.
         const blob = new Blob([buf], { type: "application/pdf" });
+        // Fingerprint the bytes while they're still readable — getDocument()
+        // below transfers the buffer to the pdf.js worker and detaches it.
+        // Hashing reads memory already in hand, so it adds no file I/O, and
+        // only the digest ever leaves the browser.
+        let sha256: string | undefined;
+        try {
+          sha256 = await sha256Hex(buf);
+        } catch {
+          // No crypto.subtle (e.g. plain-http origins): report the upload
+          // without a fingerprint rather than blocking it.
+        }
         setProgress(100);
         const doc = await getDocument({ data: new Uint8Array(buf) }).promise;
         const totalSlides = doc.numPages;
@@ -276,6 +288,10 @@ export default function Home() {
             "Couldn't store the presentation in this browser. Private/incognito mode isn't supported — please use a normal window."
           );
         }
+        // Counted only once the deck is durably stored; the analytics sink
+        // timestamps each event, so two uploads of the same filename can be
+        // compared by hash to spot recompiled vs. re-uploaded decks.
+        track("upload", { filename, sha256, size: file.size, slides: totalSlides });
         navigate(`/s/${id}/share`);
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : "Upload failed");


### PR DESCRIPTION
## Summary

The upload path now emits an analytics event that fingerprints the deck's bytes, so we can tell apart someone iterating on a recompiled deck (same filename, different hash) from someone re-uploading after losing a link (same filename, identical hash).

- New `sha256Hex()` helper in `client/src/lib/analytics.ts` (`crypto.subtle.digest`, hex-encoded).
- `Home.tsx`'s `upload()` (file picker + drag-and-drop, the one canonical deck-upload path) hashes the file's `ArrayBuffer` **before** `getDocument()` transfers/detaches it — no extra disk I/O, the bytes are already in memory.
- On success it emits `track("upload", { filename, sha256, size, slides })`. Only the digest leaves the browser; file contents never do. If `crypto.subtle` is unavailable (plain-http origin), the event still fires without a fingerprint rather than blocking the upload.
- Event timing comes from the Umami sink itself (each event is server-timestamped), so the gap between two uploads of the same filename is directly computable.

Deliberately out of scope: the URL/external-PDF flow and claim/sync re-uploads (`useClaim`) — those aren't fresh deck uploads of locally-held files, and the external flow doesn't retain bytes client-side.

## Acceptance criteria

- [x] The upload analytics event carries a content hash of the uploaded PDF, alongside filename — `track("upload", { filename, sha256, ... })`
- [x] The hash is derived client-side and no file contents leave the browser as part of analytics — hashed in-browser via WebCrypto; only the 64-char hex digest is sent
- [x] The event carries enough to reconstruct the gap between two uploads of the same filename — `filename` + `sha256` (+ `size`) on each event; timestamps come from the analytics sink per event
- [x] The added work does not noticeably delay the upload path for large decks — hashing reads memory already held (~100 MB ≈ a few hundred ms), dwarfed by the pdf.js parse that immediately follows on the same buffer
- [x] It is possible to answer: same name + different bytes, same name + identical bytes, and the time between them — compare `sha256` per filename across events; delta between sink timestamps

Closes #8

## Verification

- `cd client && npm run lint` — clean
- `cd client && npm test` — 30 passed
- `cd server && npm test` — 27 passed
- `cd client && npm run build` (tsc -b + vite build) — succeeds
- Hash-helper output cross-checked against Node's `crypto.createHash('sha256')` for identical input
- Pre-commit hooks (eslint/tsc/secrets scan) all pass

## Human follow-ups

- Confirm the event shows up in Umami with custom-property data (`filename`, `sha256`, `size`, `slides`) once deployed — dev builds don't load the tracker script, so this can only be smoke-checked against production analytics config.
- Decide whether the URL/external-deck flow should also emit an event later (would require keeping fetched bytes around or a second fetch just for hashing).