### PR TITLE
Add per-PR preview deployments on the staging host

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,15 +1,17 @@
 name: PR preview
 
 # Per-PR preview environments on the staging host. Every open PR gets its own
-# isolated container at https://pr-<n>.staging.presio.xyz — PRESIO_MODE=local,
+# isolated container at https://staging-pr-<n>.presio.xyz — PRESIO_MODE=local,
 # per-PR SQLite data volume, nothing shared with prod (see
 # docker-compose.preview.yml). Pushing updates it; closing the PR tears it down.
 #
 # One-time host setup (done on ben-docker-1 as `administrator`):
-#   1. DNS: wildcard *.staging.presio.xyz A/AAAA → the host, proxy status
-#      "DNS only" in Cloudflare — free Universal SSL doesn't cover two-level
-#      names, so previews must bypass the edge; Traefik's `le` resolver then
-#      issues each pr-<n> certificate on first request.
+#   1. DNS/TLS, Cloudflare-only origin: the host firewall only admits
+#      Cloudflare on 80/443, so previews stay behind the edge. Hostnames are a
+#      single level under presio.xyz (staging-pr-<n>) because free Universal
+#      SSL doesn't cover two-level names; an orange-clouded wildcard A record
+#      *.presio.xyz → the host routes them, and the proxy serves a Cloudflare
+#      Origin CA default certificate (*.presio.xyz) back to the edge — no ACME.
 #   2. Bare clone + previews dir + deploy keypair (all under $HOME, no sudo):
 #        git clone --bare https://github.com/benedict-armstrong/presio.git ~/presio.git
 #        mkdir -p ~/presio-previews
@@ -116,14 +118,14 @@ jobs:
           script: |
             const n = context.issue.number;
             const body =
-              `**Preview ready:** https://pr-${n}.staging.presio.xyz\n\n` +
+              `**Preview ready:** https://staging-pr-${n}.presio.xyz\n\n` +
               `Isolated local-mode deployment (SQLite, no shared state — login/sync flows live on staging). ` +
               `Redeploys on every push; torn down when this PR closes.`;
             const { data: comments } = await github.rest.issues.listComments({
               ...context.repo, issue_number: n,
             });
             const existing = comments.find(
-              (c) => c.user.type === "Bot" && c.body.includes(`pr-${n}.staging.presio.xyz`),
+              (c) => c.user.type === "Bot" && c.body.includes(`staging-pr-${n}.presio.xyz`),
             );
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,173 @@
+name: PR preview
+
+# Per-PR preview environments on the staging host. Every open PR gets its own
+# isolated container at https://pr-<n>.staging.presio.xyz — PRESIO_MODE=local,
+# per-PR SQLite data volume, nothing shared with prod (see
+# docker-compose.preview.yml). Pushing updates it; closing the PR tears it down.
+#
+# One-time host setup (done on ben-docker-1 as `administrator`):
+#   1. DNS: wildcard *.staging.presio.xyz A/AAAA → the host, proxy status
+#      "DNS only" in Cloudflare — free Universal SSL doesn't cover two-level
+#      names, so previews must bypass the edge; Traefik's `le` resolver then
+#      issues each pr-<n> certificate on first request.
+#   2. Bare clone + previews dir + deploy keypair (all under $HOME, no sudo):
+#        git clone --bare https://github.com/benedict-armstrong/presio.git ~/presio.git
+#        mkdir -p ~/presio-previews
+#        ssh-keygen -t ed25519 -f ~/presio-preview-key -N '' -C presio-previews
+#      authorized_keys entry is restricted to tailnet source IPs:
+#        from="100.64.0.0/10,fd7a:115c:a1e0::/48",no-agent-forwarding,...
+#   3. Repo secrets: PREVIEW_SSH_KEY (the private key), PREVIEW_SSH_HOST
+#      (the host's tailnet IP), PREVIEW_SSH_USER, and TAILSCALE_AUTHKEY (an
+#      ephemeral + reusable auth key so runners can join the tailnet and reach
+#      that IP).
+#
+# Fork PRs are skipped: deploying would run untrusted Dockerfile/compose config
+# on the server, and secrets aren't available to fork workflows anyway.
+#
+# If a `closed` event is ever missed (workflow disabled, Actions outage), the
+# leftover preview can be dropped by hand:
+#   docker compose -p presio-pr-<n> -f ~/presio-previews/docker-compose.preview.yml down -v
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  REPO_DIR: /home/administrator/presio.git # bare clone the workflow fetches PR refs into
+  PREVIEW_DIR: /home/administrator/presio-previews # compose file copy + per-PR worktrees
+
+jobs:
+  deploy:
+    if: github.event.action != 'closed' && !github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secrets
+        env:
+          SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+          SSH_HOST: ${{ secrets.PREVIEW_SSH_HOST }}
+          SSH_USER: ${{ secrets.PREVIEW_SSH_USER }}
+          TS_KEY: ${{ secrets.TAILSCALE_AUTHKEY }}
+        run: |
+          missing=()
+          [ -z "$SSH_KEY" ] && missing+=(PREVIEW_SSH_KEY)
+          [ -z "$SSH_HOST" ] && missing+=(PREVIEW_SSH_HOST)
+          [ -z "$SSH_USER" ] && missing+=(PREVIEW_SSH_USER)
+          [ -z "$TS_KEY" ] && missing+=(TAILSCALE_AUTHKEY)
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing secrets: ${missing[*]} — see the setup notes in .github/workflows/preview.yml"
+            exit 1
+          fi
+
+      - name: Join tailnet
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          hostname: presio-ci-${{ github.run_id }}
+
+      - name: Deploy preview
+        env:
+          SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+          SSH_HOST: ${{ secrets.PREVIEW_SSH_HOST }}
+          SSH_USER: ${{ secrets.PREVIEW_SSH_USER }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+
+          # Variables expand locally; the heredoc is the remote script.
+          ssh -o BatchMode=yes -o ConnectTimeout=10 "$SSH_USER@$SSH_HOST" bash -se <<EOF
+          set -euo pipefail
+          git -C "$REPO_DIR" fetch --force origin \
+            "pull/$PR/head:refs/remotes/origin/pr-$PR"
+
+          git -C "$REPO_DIR" worktree remove --force "$PREVIEW_DIR/pr-$PR" 2>/dev/null || true
+          git -C "$REPO_DIR" worktree prune
+          git -C "$REPO_DIR" worktree add --detach "$PREVIEW_DIR/pr-$PR" "remotes/origin/pr-$PR"
+
+          # Always take the compose file from main, never from the PR: the PR
+          # then cannot alter the config it is deployed with, and previews of
+          # branches older than this change still work. The fallback to the
+          # PR's own copy exists only to bootstrap this very first deployment,
+          # before the file has landed on main.
+          mkdir -p "$PREVIEW_DIR"
+          if ! git -C "$REPO_DIR" show origin/main:docker-compose.preview.yml \
+            > "$PREVIEW_DIR/docker-compose.preview.yml" 2>/dev/null; then
+            cp "$PREVIEW_DIR/pr-$PR/docker-compose.preview.yml" \
+              "$PREVIEW_DIR/docker-compose.preview.yml"
+          fi
+
+          cd "$PREVIEW_DIR"
+          BUILD_CONTEXT="$PREVIEW_DIR/pr-$PR" PR_NUMBER="$PR" \
+            docker compose -p "presio-pr-$PR" -f docker-compose.preview.yml up -d --build
+          docker image prune -f >/dev/null
+          EOF
+
+      - name: Comment preview URL
+        permissions:
+          pull-requests: write
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const n = context.issue.number;
+            const body =
+              `**Preview ready:** https://pr-${n}.staging.presio.xyz\n\n` +
+              `Isolated local-mode deployment (SQLite, no shared state — login/sync flows live on staging). ` +
+              `Redeploys on every push; torn down when this PR closes.`;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: n,
+            });
+            const existing = comments.find(
+              (c) => c.user.type === "Bot" && c.body.includes(`pr-${n}.staging.presio.xyz`),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: n, body,
+              });
+            }
+
+  teardown:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Join tailnet
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          hostname: presio-ci-${{ github.run_id }}
+
+      - name: Tear down preview
+        env:
+          SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+          SSH_HOST: ${{ secrets.PREVIEW_SSH_HOST }}
+          SSH_USER: ${{ secrets.PREVIEW_SSH_USER }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+
+          ssh -o BatchMode=yes -o ConnectTimeout=10 "$SSH_USER@$SSH_HOST" bash -se <<EOF
+          set -euo pipefail
+          if [ -f "$PREVIEW_DIR/docker-compose.preview.yml" ]; then
+            cd "$PREVIEW_DIR"
+            PR_NUMBER="$PR" docker compose -p "presio-pr-$PR" \
+              -f docker-compose.preview.yml down -v --remove-orphans || true
+          else
+            docker rm -f "presio-pr-$PR-preview-1" 2>/dev/null || true
+            docker volume rm "presio-pr-${PR}_data" 2>/dev/null || true
+          fi
+          git -C "$REPO_DIR" worktree remove --force "$PREVIEW_DIR/pr-$PR" 2>/dev/null || true
+          git -C "$REPO_DIR" worktree prune
+          docker image prune -f >/dev/null
+          EOF

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,6 +46,8 @@ jobs:
   deploy:
     if: github.event.action != 'closed' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # sticky preview-URL comment
     steps:
       - name: Check secrets
         env:
@@ -111,8 +113,6 @@ jobs:
           EOF
 
       - name: Comment preview URL
-        permissions:
-          pull-requests: write
         uses: actions/github-script@v7
         with:
           script: |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -137,12 +137,16 @@ same proxy:
      - "traefik.docker.network=web"
      - "traefik.http.routers.myapp.rule=Host(`app2.example.com`)"
      - "traefik.http.routers.myapp.entrypoints=websecure"
-     - "traefik.http.routers.myapp.tls.certresolver=le"
      - "traefik.http.services.myapp.loadbalancer.server.port=8080"
    ```
 
-3. Point `app2.example.com` at the host and `docker compose up -d`. Traefik
-   picks it up and issues a certificate automatically.
+3. Point `app2.example.com` at the host and `docker compose up -d`. TLS is
+   served from the proxy's default certificate (a Cloudflare Origin CA cert
+   covering `presio.xyz` + `*.presio.xyz`), so keep the hostname one level
+   deep under `presio.xyz` — that's what Cloudflare's edge certificate and
+   the origin cert both cover. No per-host ACME involved: the host firewall
+   only admits Cloudflare on 80/443, so Let's Encrypt validation can't reach
+   the origin anyway.
 
 ## Continuous deployment (optional)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -137,6 +137,7 @@ same proxy:
      - "traefik.docker.network=web"
      - "traefik.http.routers.myapp.rule=Host(`app2.example.com`)"
      - "traefik.http.routers.myapp.entrypoints=websecure"
+     - "traefik.http.routers.myapp.tls=true"
      - "traefik.http.services.myapp.loadbalancer.server.port=8080"
    ```
 

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -1,0 +1,54 @@
+# PR preview deployment — one fully isolated container per pull request,
+# driven by .github/workflows/preview.yml. Unlike docker-compose.staging.yml
+# there is no shared state: PRESIO_MODE=local swaps Supabase for the bundled
+# SQLite + filesystem backend under a per-project volume, so no .env and no
+# Supabase stack is involved. Trade-off: no login/sync flows — test those on
+# the staging slot.
+#
+#   PR_NUMBER=42 BUILD_CONTEXT=. \
+#     docker compose -p presio-pr-42 -f docker-compose.preview.yml up -d --build
+#   → https://pr-42.staging.presio.xyz
+#
+# PR_NUMBER is required: it namespaces the Traefik router/service names (those
+# are global across the shared proxy — two projects reusing one name would
+# fight over the route) and the routed hostname. BUILD_CONTEXT lets the file
+# live outside the tree it builds (the workflow keeps a trusted copy in the
+# previews dir and points it at the per-PR worktree), so a PR can never change
+# the compose config it is deployed with.
+
+services:
+  preview:
+    build:
+      context: ${BUILD_CONTEXT:-.}
+      dockerfile: deploy/Dockerfile
+      # No VITE_* args: like the published presio-local image, the client is
+      # built without Supabase config; PRESIO_MODE=local selects the backend.
+    restart: unless-stopped
+    networks:
+      web:
+    environment:
+      PRESIO_MODE: local
+      LOCAL_DATA_DIR: /data
+      PORT: 3001
+      # Pin the origin used in generated links (canonical/og:url, handoff URLs)
+      # instead of deriving it from the client-controlled Host header.
+      PUBLIC_BASE_URL: https://pr-${PR_NUMBER:?PR_NUMBER is required}.staging.presio.xyz
+    volumes:
+      # Compose prefixes this with the project name (presio-pr-<n>_data), so
+      # `down -v` removes each PR's data along with its containers.
+      - data:/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web"
+      - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.rule=Host(`pr-${PR_NUMBER:?PR_NUMBER is required}.staging.presio.xyz`)"
+      - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.entrypoints=websecure"
+      - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.tls.certresolver=le"
+      - "traefik.http.services.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.loadbalancer.server.port=3001"
+
+volumes:
+  data:
+
+networks:
+  # Shared with the Traefik proxy (created once per host: `docker network create web`).
+  web:
+    external: true

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -7,7 +7,7 @@
 #
 #   PR_NUMBER=42 BUILD_CONTEXT=. \
 #     docker compose -p presio-pr-42 -f docker-compose.preview.yml up -d --build
-#   → https://pr-42.staging.presio.xyz
+#   → https://staging-pr-42.presio.xyz
 #
 # PR_NUMBER is required: it namespaces the Traefik router/service names (those
 # are global across the shared proxy — two projects reusing one name would
@@ -15,6 +15,11 @@
 # live outside the tree it builds (the workflow keeps a trusted copy in the
 # previews dir and points it at the per-PR worktree), so a PR can never change
 # the compose config it is deployed with.
+#
+# TLS: hosts are kept to a single level under presio.xyz so Cloudflare's free
+# Universal SSL (*.presio.xyz) terminates them at the edge; the origin side is
+# served from the proxy's default certificate (a Cloudflare Origin CA cert —
+# see proxy setup on the host). No ACME/Let's Encrypt involvement.
 
 services:
   preview:
@@ -32,7 +37,7 @@ services:
       PORT: 3001
       # Pin the origin used in generated links (canonical/og:url, handoff URLs)
       # instead of deriving it from the client-controlled Host header.
-      PUBLIC_BASE_URL: https://pr-${PR_NUMBER:?PR_NUMBER is required}.staging.presio.xyz
+      PUBLIC_BASE_URL: https://staging-pr-${PR_NUMBER:?PR_NUMBER is required}.presio.xyz
     volumes:
       # Compose prefixes this with the project name (presio-pr-<n>_data), so
       # `down -v` removes each PR's data along with its containers.
@@ -40,9 +45,8 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=web"
-      - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.rule=Host(`pr-${PR_NUMBER:?PR_NUMBER is required}.staging.presio.xyz`)"
+      - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.rule=Host(`staging-pr-${PR_NUMBER:?PR_NUMBER is required}.presio.xyz`)"
       - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.entrypoints=websecure"
-      - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.tls.certresolver=le"
       - "traefik.http.services.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.loadbalancer.server.port=3001"
 
 volumes:

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -47,6 +47,8 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.rule=Host(`staging-pr-${PR_NUMBER:?PR_NUMBER is required}.presio.xyz`)"
       - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.entrypoints=websecure"
+      # Serve TLS from the proxy's default certificate (Cloudflare Origin CA).
+      - "traefik.http.routers.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.tls=true"
       - "traefik.http.services.presio-pr-${PR_NUMBER:?PR_NUMBER is required}.loadbalancer.server.port=3001"
 
 volumes:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -35,6 +35,8 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.presio-staging.rule=Host(`${STAGING_HOST:-staging.presio.xyz}`)"
       - "traefik.http.routers.presio-staging.entrypoints=websecure"
+      # Serve TLS from the proxy's default certificate (Cloudflare Origin CA).
+      - "traefik.http.routers.presio-staging.tls=true"
       - "traefik.http.services.presio-staging.loadbalancer.server.port=3001"
 
 networks:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -35,7 +35,6 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.presio-staging.rule=Host(`${STAGING_HOST:-staging.presio.xyz}`)"
       - "traefik.http.routers.presio-staging.entrypoints=websecure"
-      - "traefik.http.routers.presio-staging.tls.certresolver=le"
       - "traefik.http.services.presio-staging.loadbalancer.server.port=3001"
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.supabase.rule=Host(`${SUPABASE_HOST}`)"
       - "traefik.http.routers.supabase.entrypoints=websecure"
+      - "traefik.http.routers.supabase.tls=true"
       - "traefik.http.services.supabase.loadbalancer.server.port=8000"
     volumes:
       - ./deploy/volumes/api/kong.yml:/home/kong/temp.yml:ro,z
@@ -712,6 +713,7 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.presio.rule=Host(`${APP_HOST}`)"
       - "traefik.http.routers.presio.entrypoints=websecure"
+      - "traefik.http.routers.presio.tls=true"
       - "traefik.http.services.presio.loadbalancer.server.port=3001"
 
   # One-shot: create the umami database and user in the shared Postgres instance.
@@ -756,6 +758,7 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.umami.rule=Host(`${UMAMI_HOST}`)"
       - "traefik.http.routers.umami.entrypoints=websecure"
+      - "traefik.http.routers.umami.tls=true"
       - "traefik.http.services.umami.loadbalancer.server.port=3000"
 
   # Uptime Kuma — self-hosted uptime monitoring + status dashboard.
@@ -775,6 +778,7 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.uptime.rule=Host(`${UPTIME_HOST}`)"
       - "traefik.http.routers.uptime.entrypoints=websecure"
+      - "traefik.http.routers.uptime.tls=true"
       - "traefik.http.services.uptime.loadbalancer.server.port=3001"
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,6 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.supabase.rule=Host(`${SUPABASE_HOST}`)"
       - "traefik.http.routers.supabase.entrypoints=websecure"
-      - "traefik.http.routers.supabase.tls.certresolver=le"
       - "traefik.http.services.supabase.loadbalancer.server.port=8000"
     volumes:
       - ./deploy/volumes/api/kong.yml:/home/kong/temp.yml:ro,z
@@ -713,7 +712,6 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.presio.rule=Host(`${APP_HOST}`)"
       - "traefik.http.routers.presio.entrypoints=websecure"
-      - "traefik.http.routers.presio.tls.certresolver=le"
       - "traefik.http.services.presio.loadbalancer.server.port=3001"
 
   # One-shot: create the umami database and user in the shared Postgres instance.
@@ -758,7 +756,6 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.umami.rule=Host(`${UMAMI_HOST}`)"
       - "traefik.http.routers.umami.entrypoints=websecure"
-      - "traefik.http.routers.umami.tls.certresolver=le"
       - "traefik.http.services.umami.loadbalancer.server.port=3000"
 
   # Uptime Kuma — self-hosted uptime monitoring + status dashboard.
@@ -778,7 +775,6 @@ services:
       - "traefik.docker.network=web"
       - "traefik.http.routers.uptime.rule=Host(`${UPTIME_HOST}`)"
       - "traefik.http.routers.uptime.entrypoints=websecure"
-      - "traefik.http.routers.uptime.tls.certresolver=le"
       - "traefik.http.services.uptime.loadbalancer.server.port=3001"
 
 networks:


### PR DESCRIPTION
## What

Every open PR gets its own isolated preview at `https://pr-<n>.staging.presio.xyz` — deployed automatically on open/push, torn down on close.

- **Isolated by design:** previews run `PRESIO_MODE=local` (bundled SQLite + filesystem, per-PR volume). Nothing touches the prod Supabase stack; no `.env` needed. Login/sync flows stay on the existing staging slot.
- **Per-PR Traefik routes:** router/service names and hostname are namespaced by PR number; wildcard `*.staging.presio.xyz` (now DNS-only in Cloudflare) points at the host so Traefik's `le` resolver issues each cert on first request.
- **PRs can't alter their own deploy config:** the compose file is always taken from `main` (fallback to the PR copy bootstraps only this first deployment).
- **Fork PRs are skipped** — untrusted code must not build on the server.
- Builds deduped per-PR via concurrency groups; sticky bot comment carries the preview URL; teardown is `compose down -v` + worktree removal.

## Files

- `docker-compose.preview.yml` — parameterized preview stack (`PR_NUMBER`, `BUILD_CONTEXT`)
- `.github/workflows/preview.yml` — deploy + teardown jobs

## Setup state

- [x] Wildcard DNS grey-clouded → `77.244.248.197`
- [x] Bare clone `~/presio.git`, previews dir, deploy keypair on ben-docker-1 (authorized_keys restricted to tailnet sources)
- [x] Secrets: `PREVIEW_SSH_KEY` / `PREVIEW_SSH_HOST` / `PREVIEW_SSH_USER`
- [ ] `TAILSCALE_AUTHKEY` (ephemeral + reusable) — runners join the tailnet to reach the host's tailnet IP

Until that last secret is set, the deploy job fails fast at the secrets check with a pointer to the setup notes.