### PR TITLE
Allow the PR preview deploy to be dispatched manually

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -33,9 +33,19 @@ name: PR preview
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
+  # Manual redeploy for when a push doesn't reach Actions (a missed
+  # `synchronize` event leaves the preview running the previous commit) or a
+  # deploy needs repeating after a host-side fix. Always deploys the current
+  # head of `pull/<pr>/head`, so it can't resurrect a stale commit.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to (re)deploy
+        required: true
+        type: string
 
 concurrency:
-  group: preview-${{ github.event.pull_request.number }}
+  group: preview-${{ github.event.pull_request.number || inputs.pr }}
   cancel-in-progress: true
 
 env:
@@ -44,7 +54,9 @@ env:
 
 jobs:
   deploy:
-    if: github.event.action != 'closed' && !github.event.pull_request.head.repo.fork
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action != 'closed' && !github.event.pull_request.head.repo.fork)
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # sticky preview-URL comment
@@ -77,7 +89,7 @@ jobs:
           SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
           SSH_HOST: ${{ secrets.PREVIEW_SSH_HOST }}
           SSH_USER: ${{ secrets.PREVIEW_SSH_USER }}
-          PR: ${{ github.event.pull_request.number }}
+          PR: ${{ github.event.pull_request.number || inputs.pr }}
         run: |
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
@@ -114,9 +126,13 @@ jobs:
 
       - name: Comment preview URL
         uses: actions/github-script@v7
+        env:
+          # context.issue is empty on a manual dispatch, so the number comes
+          # from the event or the input, same as the deploy step.
+          PR: ${{ github.event.pull_request.number || inputs.pr }}
         with:
           script: |
-            const n = context.issue.number;
+            const n = Number(process.env.PR);
             const body =
               `**Preview ready:** https://staging-pr-${n}.presio.xyz\n\n` +
               `Isolated local-mode deployment (SQLite, no shared state — login/sync flows live on staging). ` +


### PR DESCRIPTION
## Why

A push can update a PR head without Actions dispatching a run — hit on #25, where two pushes (a fix and an empty commit) both updated the head with no workflow run at all. The preview then keeps serving the previous commit, and there's no way to redeploy: `preview.yml` only triggered on `pull_request` events, and re-running the last run redeploys its own (stale) sha.

## What

- `workflow_dispatch` with a required `pr` input.
- PR number resolves as `github.event.pull_request.number || inputs.pr` in the concurrency group, the deploy step, and the sticky-comment step (`context.issue` is empty on a manual dispatch, so the number comes through env instead).
- `deploy` also runs when `event_name == 'workflow_dispatch'`; `teardown` stays tied to the `closed` event.

A dispatched run takes the same path as the automatic one — it fetches `pull/<pr>/head` on the host — so it always deploys the current head of that PR, never a stale commit.

Note that `workflow_dispatch` only becomes available once this is on `main`.