### PR TITLE
Replace the PDF of an existing presentation in place

### DIFF
--- a/client/src/components/controller/ConfirmReplaceDialog.tsx
+++ b/client/src/components/controller/ConfirmReplaceDialog.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@/components/ui/button";
+import { DialogOverlay } from "@/components/ui/dialog-overlay";
+
+// "Replace PDF?" confirmation shared by the controller and the home screen's
+// recents list. Replacing swaps the deck's bytes under the same code, so the
+// user should know what doesn't survive: drawings (keyed by slide number) and
+// speaker notes edited inside Presio but not baked into the new file.
+export function ConfirmReplaceDialog({
+  onConfirm,
+  onClose,
+}: {
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <DialogOverlay onClose={onClose}>
+      <div className="space-y-2 text-center">
+        <h2 className="text-lg font-semibold">Replace PDF?</h2>
+        <p className="text-sm text-muted-foreground">
+          The presentation keeps its code, link and passphrase, but existing
+          drawings are cleared and speaker notes edited in Presio are lost — the
+          new file's own notes are used instead.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Button className="flex-1" variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button className="flex-1" onClick={onConfirm}>
+          Replace
+        </Button>
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/client/src/components/controller/ControllerMenu.tsx
+++ b/client/src/components/controller/ControllerMenu.tsx
@@ -1,5 +1,5 @@
 import type { Deck } from "@/lib/deck";
-import { Menu, X, QrCode } from "lucide-react";
+import { Menu, X, QrCode, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { DownloadButton } from "@/components/DownloadButton";
@@ -19,6 +19,7 @@ export function ControllerMenu({
   onToggleCode,
   onShowPassphrase,
   onSwitchToViewer,
+  onReplaceClick,
   onEndClick,
 }: {
   open: boolean;
@@ -33,6 +34,7 @@ export function ControllerMenu({
   onToggleCode: () => void;
   onShowPassphrase: () => void;
   onSwitchToViewer: () => void;
+  onReplaceClick: () => void;
   onEndClick: () => void;
 }) {
   // Run an action after dismissing the drawer.
@@ -76,6 +78,10 @@ export function ControllerMenu({
               )}
               <Button variant="ghost" className="justify-start" onClick={act(onSwitchToViewer)}>
                 Switch to Viewer
+              </Button>
+              <Button variant="ghost" className="justify-start" onClick={act(onReplaceClick)}>
+                <RefreshCw size={16} className="mr-2" />
+                Replace PDF…
               </Button>
               <DownloadButton deck={deck} block />
               <div className="flex items-center justify-between px-4 py-2">

--- a/client/src/components/controller/ThumbnailsCard.tsx
+++ b/client/src/components/controller/ThumbnailsCard.tsx
@@ -26,6 +26,12 @@ export function ThumbnailsCard({
   }, [pdf]);
 
   useEffect(() => {
+    // A swapped document (notes edit, deck replace) invalidates every rendered
+    // thumbnail: drop the old canvases so the observer below re-renders them
+    // from the new document instead of keeping whatever was on screen.
+    thumbRefs.current.forEach((el) => {
+      el.innerHTML = "";
+    });
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
@@ -72,7 +78,10 @@ export function ThumbnailsCard({
           style={aspectRatio ? { aspectRatio, minWidth: 80 } : { minWidth: 80 }}
         >
           <div
-            ref={(el) => { if (el) thumbRefs.current.set(num, el); }}
+            ref={(el) => {
+              if (el) thumbRefs.current.set(num, el);
+              else thumbRefs.current.delete(num);
+            }}
             data-page={num}
             className="w-full h-full"
           />

--- a/client/src/pages/ControllerView.tsx
+++ b/client/src/pages/ControllerView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { cn, getSessionAuth } from "@/lib/utils";
-import { Settings, Check, Option, Plus, Share2, ExternalLink, QrCode, Save, FolderOpen, PenLine } from "lucide-react";
+import { Settings, Check, Option, Plus, Share2, ExternalLink, QrCode, Save, FolderOpen, PenLine, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { buttonVariants } from "@/components/ui/button-variants";
 import { Separator } from "@/components/ui/separator";
@@ -32,6 +32,7 @@ import { ControllerDashboard, type CardEntry } from "@/components/controller/Con
 import { ControllerStack } from "@/components/controller/ControllerStack";
 import { ShareDialog } from "@/components/controller/ShareDialog";
 import { ConfirmEndDialog } from "@/components/controller/ConfirmEndDialog";
+import { ConfirmReplaceDialog } from "@/components/controller/ConfirmReplaceDialog";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useSlideTapNav } from "@/hooks/useSlideTapNav";
 import {
@@ -72,6 +73,7 @@ interface ControllerViewProps {
   onEnd: () => void;
   onSynced: () => void;
   onSaveNotes: (slide: number, notes: string) => Promise<void>;
+  onReplacePdf: (file: File) => Promise<void>;
   currentCanvasRef: React.RefObject<HTMLDivElement | null>;
   blanked: boolean;
   onBlankToggle: () => void;
@@ -102,6 +104,7 @@ export function ControllerView({
   onEnd,
   onSynced,
   onSaveNotes,
+  onReplacePdf,
   currentCanvasRef,
   blanked,
   onBlankToggle,
@@ -193,6 +196,28 @@ export function ControllerView({
   // Hidden file input for loading a saved drawing from Settings.
   const drawingFileRef = useRef<HTMLInputElement | null>(null);
 
+  // Deck replacement: pick a PDF, confirm, then hand it to the orchestrator.
+  // The File is held in state between the picker and the confirmation dialog.
+  const replaceFileRef = useRef<HTMLInputElement | null>(null);
+  const [replaceCandidate, setReplaceCandidate] = useState<File | null>(null);
+  const [replacing, setReplacing] = useState(false);
+  const onReplacePicked = useCallback((file: File | undefined) => {
+    if (file) setReplaceCandidate(file);
+  }, []);
+  const confirmReplace = useCallback(async () => {
+    const file = replaceCandidate;
+    if (!file || replacing) return;
+    setReplacing(true);
+    try {
+      await onReplacePdf(file);
+      setReplaceCandidate(null);
+    } catch (e) {
+      window.alert(e instanceof Error ? e.message : "Failed to replace the PDF");
+    } finally {
+      setReplacing(false);
+    }
+  }, [replaceCandidate, replacing, onReplacePdf]);
+
   const { user } = useAuth();
   const loggedIn = !!user;
   // Drawing and notes editing are purely local (canvas state / IndexedDB), so
@@ -215,9 +240,8 @@ export function ControllerView({
     // Only prompt if the presenter hasn't already opened a viewer for this
     // presentation (the flag survives controller refreshes).
     if (lsGetString(viewerOpenedKey(id)) === "true") return;
-    // One-time mount prompt (re-armed when onboarding finishes); the single
-    // extra render the rule warns about is intentional and harmless here.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    // One-time mount prompt (re-armed when onboarding finishes); the extra
+    // render from setting state in the effect is intentional and harmless.
     setViewerPromptOpen(true);
   }, [id, isMobile, onboardingOpen]);
 
@@ -436,6 +460,7 @@ export function ControllerView({
       onToggleCode={onShowCodeToggle}
       onShowPassphrase={() => setPassphraseDialogOpen(true)}
       onSwitchToViewer={() => navigate(`/s/${id}?role=viewer`, { replace: true })}
+      onReplaceClick={() => replaceFileRef.current?.click()}
       onEndClick={() => setConfirmEnd(true)}
     />
   );
@@ -594,6 +619,28 @@ export function ControllerView({
           <Separator />
 
           <section className="space-y-2">
+            <h3 className="text-sm font-medium">Presentation</h3>
+            <p className="text-xs text-muted-foreground">
+              Swap in a recompiled PDF. The code, link and passphrase stay the
+              same; drawings are cleared and Presio-edited notes are lost.
+            </p>
+            <div>
+              <Button
+                size="sm"
+                variant="outline"
+                data-testid="deck-replace"
+                disabled={replacing}
+                onClick={() => replaceFileRef.current?.click()}
+              >
+                <RefreshCw size={14} className={cn("mr-1", replacing && "animate-spin")} />
+                {replacing ? "Replacing…" : "Replace PDF…"}
+              </Button>
+            </div>
+          </section>
+
+          <Separator />
+
+          <section className="space-y-2">
             <h3 className="text-sm font-medium">Drawing</h3>
             <p className="text-xs text-muted-foreground">
               Save the drawings made on the slides to a file, or load a previously saved drawing.
@@ -684,6 +731,27 @@ export function ControllerView({
       {confirmEnd && (
         <ConfirmEndDialog local={local} onConfirm={onEnd} onClose={() => setConfirmEnd(false)} />
       )}
+
+      {replaceCandidate && (
+        <ConfirmReplaceDialog
+          onConfirm={confirmReplace}
+          onClose={() => { if (!replacing) setReplaceCandidate(null); }}
+        />
+      )}
+
+      {/* Always mounted: both the desktop Settings button and the mobile menu
+          item trigger this picker, which then opens the confirm dialog. */}
+      <input
+        ref={replaceFileRef}
+        type="file"
+        accept=".pdf,application/pdf"
+        className="hidden"
+        data-testid="deck-replace-input"
+        onChange={(e) => {
+          onReplacePicked(e.target.files?.[0]);
+          e.target.value = "";
+        }}
+      />
 
       {passphraseDialogOpen && passphrase && (
         <DialogOverlay onClose={() => setPassphraseDialogOpen(false)} maxWidth="max-w-xs">

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -9,8 +9,8 @@ import { PresioLogo } from "@/components/PresioLogo";
 import { MobileNotice } from "@/components/MobileNotice";
 import { CodeBlock } from "@/components/CodeBlock";
 import { ConfirmReplaceDialog } from "@/components/controller/ConfirmReplaceDialog";
-import { idbPut, idbList, type LocalPresentationMeta } from "@/lib/localStore";
-import { setSessionAuth } from "@/lib/utils";
+import { idbPut, idbList } from "@/lib/localStore";
+import { getSessionAuth, setSessionAuth } from "@/lib/utils";
 import { lsRemove, annotationsKey } from "@/lib/storage";
 import { track, sha256Hex } from "@/lib/analytics";
 import { loadExternalPdfMeta, createExternalSession } from "@/lib/externalSession";
@@ -227,6 +227,61 @@ function formatRecentDate(ts: number): string {
   return d.toLocaleDateString(undefined, opts);
 }
 
+// One row in the recents list: everything this browser could control. Local
+// decks come from IndexedDB; synced ones are discovered through the controller
+// credentials this browser holds (created+synced here, or taken over via
+// passphrase) — the IndexedDB record is deleted on claim, so without the
+// credential scan a shared deck would vanish from the list.
+interface RecentDeck {
+  id: string;
+  filename: string;
+  totalSlides: number;
+  /** Present only for local decks (IndexedDB creation time). */
+  createdAt: number | null;
+  kind: "local" | "synced";
+}
+
+const SESSION_KEY_RE = /^session_([A-Z0-9]{6})$/;
+
+async function listControlledSynced(): Promise<RecentDeck[]> {
+  const ids: string[] = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      const m = key.match(SESSION_KEY_RE);
+      if (m && localStorage.getItem(key)?.includes("controllerToken")) ids.push(m[1]);
+    }
+  } catch {
+    return []; // storage unavailable (private mode): nothing to scan
+  }
+  const out: RecentDeck[] = [];
+  // A browser only controls a handful of decks; a small sequential scan keeps
+  // this trivial and ordered by insertion (most recent credential first).
+  for (const id of ids.slice(0, 20)) {
+    try {
+      const res = await fetch(`/api/sessions/${id}`);
+      if (!res.ok) {
+        // Ended or expired server-side: the stored credential is dead weight.
+        lsRemove(`session_${id}`);
+        continue;
+      }
+      const s = await res.json();
+      if (s.local) continue; // local rows are listed from IndexedDB above
+      out.push({
+        id,
+        filename: s.filename,
+        totalSlides: s.total_slides,
+        createdAt: null,
+        kind: "synced",
+      });
+    } catch {
+      // Offline or server unreachable: skip rather than block the page.
+    }
+  }
+  return out;
+}
+
 export default function Home() {
   const navigate = useNavigate();
   const [dragging, setDragging] = useState(false);
@@ -243,19 +298,44 @@ export default function Home() {
   const [exampleBusy, setExampleBusy] = useState<"typst" | "latex" | null>(null);
   const [exampleError, setExampleError] = useState("");
 
-  // Presentations this browser holds locally, with an in-place "Replace PDF"
+  // Presentations this browser could control, with an in-place "Replace PDF"
   // action so a recompiled deck keeps its code instead of minting a new one.
-  const [recents, setRecents] = useState<LocalPresentationMeta[]>([]);
+  const [recents, setRecents] = useState<RecentDeck[]>([]);
   const replaceInputRef = useRef<HTMLInputElement | null>(null);
-  const [replaceTarget, setReplaceTarget] = useState<LocalPresentationMeta | null>(null);
+  const [replaceTarget, setReplaceTarget] = useState<RecentDeck | null>(null);
   const [replaceFile, setReplaceFile] = useState<File | null>(null);
   const [replacing, setReplacing] = useState(false);
 
   useEffect(() => {
-    idbList().then(setRecents).catch(() => { /* no IndexedDB: no recents */ });
+    let cancelled = false;
+    (async () => {
+      const locals = await idbList()
+        .then((rs) =>
+          rs.map<RecentDeck>((r) => ({
+            id: r.id,
+            filename: r.filename,
+            totalSlides: r.totalSlides,
+            createdAt: r.createdAt,
+            kind: "local",
+          }))
+        )
+        .catch(() => [] as RecentDeck[]);
+      const controlled = await listControlledSynced();
+      if (cancelled) return;
+      // Locals first (they carry a creation date), then synced decks this
+      // browser holds credentials for; dedupe by id, preferring the local copy.
+      const byId = new Map<string, RecentDeck>();
+      for (const deck of [...locals, ...controlled]) {
+        if (!byId.has(deck.id)) byId.set(deck.id, deck);
+      }
+      setRecents([...byId.values()]);
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [uploading]);
 
-  const pickReplace = useCallback((target: LocalPresentationMeta) => {
+  const pickReplace = useCallback((target: RecentDeck) => {
     setReplaceFile(null);
     setReplaceTarget(target);
     replaceInputRef.current?.click();
@@ -274,12 +354,45 @@ export default function Home() {
       const totalSlides = doc.numPages;
       doc.destroy();
       const filename = replaceFile.name.replace(/\.pdf$/i, "");
-      try {
-        await idbPut({ ...replaceTarget, blob, filename, totalSlides });
-      } catch {
-        throw new Error(
-          "Couldn't update the presentation in this browser. Private/incognito mode isn't supported — please use a normal window."
-        );
+      if (replaceTarget.kind === "local") {
+        try {
+          await idbPut({
+            id: replaceTarget.id,
+            filename,
+            totalSlides,
+            blob,
+            createdAt: replaceTarget.createdAt ?? Date.now(),
+          });
+        } catch {
+          throw new Error(
+            "Couldn't update the presentation in this browser. Private/incognito mode isn't supported — please use a normal window."
+          );
+        }
+      } else {
+        // Synced deck: overwrite its server copy. The controller token this
+        // browser holds authorizes the write; a logged-in owner token is
+        // attached too when present (the server accepts either).
+        const { controllerToken } = getSessionAuth(replaceTarget.id);
+        if (!controllerToken) {
+          throw new Error("This browser isn't the controller for this presentation");
+        }
+        const headers: Record<string, string> = { "x-controller-token": controllerToken };
+        const { data: sessionData } = await supabase.auth.getSession();
+        if (sessionData.session) {
+          headers.Authorization = `Bearer ${sessionData.session.access_token}`;
+        }
+        const form = new FormData();
+        form.append("pdf", blob, `${filename}.pdf`);
+        form.append("filename", filename);
+        const res = await fetch(`/api/sessions/${replaceTarget.id}/pdf`, {
+          method: "POST",
+          headers,
+          body: form,
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || "Failed to replace the PDF");
+        }
       }
       // Drawings are keyed by slide number; a replaced deck invalidates them.
       lsRemove(annotationsKey(replaceTarget.id));
@@ -294,7 +407,7 @@ export default function Home() {
         sha256,
         size: replaceFile.size,
         slides: totalSlides,
-        mode: "local",
+        mode: replaceTarget.kind === "local" ? "local" : "server",
       });
       navigate(`/s/${replaceTarget.id}?role=controller`);
     } catch (e: unknown) {
@@ -629,7 +742,7 @@ export default function Home() {
               {recents.length > 0 && (
                 <div className="mt-8">
                   <div className="mb-2 font-mono text-xs uppercase tracking-wide text-muted-foreground">
-                    On this device
+                    Recent presentations
                   </div>
                   <ul className="space-y-1.5">
                     {recents.map((r) => (
@@ -640,7 +753,14 @@ export default function Home() {
                         <div className="min-w-0 flex-1">
                           <p className="truncate text-sm font-medium">{r.filename}</p>
                           <p className="text-xs text-muted-foreground">
-                            {r.totalSlides} {r.totalSlides === 1 ? "slide" : "slides"} · {formatRecentDate(r.createdAt)}
+                            {r.totalSlides} {r.totalSlides === 1 ? "slide" : "slides"}
+                            {" · "}
+                            <span
+                              className={r.kind === "synced" ? "text-(--home2-accent)" : undefined}
+                            >
+                              {r.kind === "synced" ? "synced" : "local"}
+                            </span>
+                            {r.createdAt !== null && ` · ${formatRecentDate(r.createdAt)}`}
                           </p>
                         </div>
                         <Button

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -758,7 +758,7 @@ export default function Home() {
                             <span
                               className={r.kind === "synced" ? "text-(--home2-accent)" : undefined}
                             >
-                              {r.kind === "synced" ? "synced" : "local"}
+                              {r.kind === "synced" ? "shared" : "local"}
                             </span>
                             {r.createdAt !== null && ` · ${formatRecentDate(r.createdAt)}`}
                           </p>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,15 +1,17 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { getDocument } from "pdfjs-dist";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { AccountControl } from "@/components/AccountControl";
 import { PresioLogo } from "@/components/PresioLogo";
 import { MobileNotice } from "@/components/MobileNotice";
 import { CodeBlock } from "@/components/CodeBlock";
-import { idbPut } from "@/lib/localStore";
+import { ConfirmReplaceDialog } from "@/components/controller/ConfirmReplaceDialog";
+import { idbPut, idbList, type LocalPresentationMeta } from "@/lib/localStore";
 import { setSessionAuth } from "@/lib/utils";
+import { lsRemove, annotationsKey } from "@/lib/storage";
 import { track, sha256Hex } from "@/lib/analytics";
 import { loadExternalPdfMeta, createExternalSession } from "@/lib/externalSession";
 import { supabase } from "@/lib/supabaseClient";
@@ -196,8 +198,7 @@ function ScrollReveal({ children, className = "" }: { children: React.ReactNode;
   );
 }
 
-function Cue({ cue, index, flip }: { cue: (typeof CUES)[number]; index: number; flip: boolean }) {
-  return (
+function Cue({ cue, index, flip }: { cue: (typeof CUES)[number]; index: number; flip: boolean }) {  return (
     <ScrollReveal className="grid grid-cols-1 items-center gap-7 md:grid-cols-2 md:gap-16">
       <div className={flip ? "md:order-2" : "md:order-1"}>
         <div className="mb-3.5 flex items-center gap-2.5 font-mono text-xs font-semibold uppercase tracking-wide text-[var(--home2-accent)]">
@@ -216,6 +217,16 @@ function Cue({ cue, index, flip }: { cue: (typeof CUES)[number]; index: number; 
   );
 }
 
+// Compact date for the recents list: "Aug 25" this year, otherwise "Aug 25, 2025".
+function formatRecentDate(ts: number): string {
+  const d = new Date(ts);
+  const opts: Intl.DateTimeFormatOptions =
+    d.getFullYear() === new Date().getFullYear()
+      ? { month: "short", day: "numeric" }
+      : { month: "short", day: "numeric", year: "numeric" };
+  return d.toLocaleDateString(undefined, opts);
+}
+
 export default function Home() {
   const navigate = useNavigate();
   const [dragging, setDragging] = useState(false);
@@ -231,6 +242,67 @@ export default function Home() {
   const [scrolled, setScrolled] = useState(false);
   const [exampleBusy, setExampleBusy] = useState<"typst" | "latex" | null>(null);
   const [exampleError, setExampleError] = useState("");
+
+  // Presentations this browser holds locally, with an in-place "Replace PDF"
+  // action so a recompiled deck keeps its code instead of minting a new one.
+  const [recents, setRecents] = useState<LocalPresentationMeta[]>([]);
+  const replaceInputRef = useRef<HTMLInputElement | null>(null);
+  const [replaceTarget, setReplaceTarget] = useState<LocalPresentationMeta | null>(null);
+  const [replaceFile, setReplaceFile] = useState<File | null>(null);
+  const [replacing, setReplacing] = useState(false);
+
+  useEffect(() => {
+    idbList().then(setRecents).catch(() => { /* no IndexedDB: no recents */ });
+  }, [uploading]);
+
+  const pickReplace = useCallback((target: LocalPresentationMeta) => {
+    setReplaceFile(null);
+    setReplaceTarget(target);
+    replaceInputRef.current?.click();
+  }, []);
+
+  const confirmReplace = useCallback(async () => {
+    if (!replaceTarget || !replaceFile || replacing) return;
+    setReplacing(true);
+    setError("");
+    try {
+      const buf = await replaceFile.arrayBuffer();
+      // Snapshot the bytes before getDocument() transfers the buffer to the
+      // pdf.js worker and detaches it (same ordering as upload()).
+      const blob = new Blob([buf], { type: "application/pdf" });
+      const doc = await getDocument({ data: new Uint8Array(buf) }).promise;
+      const totalSlides = doc.numPages;
+      doc.destroy();
+      const filename = replaceFile.name.replace(/\.pdf$/i, "");
+      try {
+        await idbPut({ ...replaceTarget, blob, filename, totalSlides });
+      } catch {
+        throw new Error(
+          "Couldn't update the presentation in this browser. Private/incognito mode isn't supported — please use a normal window."
+        );
+      }
+      // Drawings are keyed by slide number; a replaced deck invalidates them.
+      lsRemove(annotationsKey(replaceTarget.id));
+      let sha256: string | undefined;
+      try {
+        sha256 = await sha256Hex(buf);
+      } catch {
+        // No crypto.subtle (plain-http origins): track without a fingerprint.
+      }
+      track("deck-replace", {
+        filename,
+        sha256,
+        size: replaceFile.size,
+        slides: totalSlides,
+        mode: "local",
+      });
+      navigate(`/s/${replaceTarget.id}?role=controller`);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to replace the PDF");
+    } finally {
+      setReplacing(false);
+    }
+  }, [replaceTarget, replaceFile, replacing, navigate]);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 8);
@@ -553,6 +625,46 @@ export default function Home() {
                   />
                 ))}
               </div>
+
+              {recents.length > 0 && (
+                <div className="mt-8">
+                  <div className="mb-2 font-mono text-xs uppercase tracking-wide text-muted-foreground">
+                    On this device
+                  </div>
+                  <ul className="space-y-1.5">
+                    {recents.map((r) => (
+                      <li
+                        key={r.id}
+                        className="flex items-center gap-2 rounded-md border px-3 py-2"
+                      >
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-medium">{r.filename}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {r.totalSlides} {r.totalSlides === 1 ? "slide" : "slides"} · {formatRecentDate(r.createdAt)}
+                          </p>
+                        </div>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => navigate(`/s/${r.id}?role=controller`)}
+                        >
+                          Open
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          title="Swap in a recompiled PDF — keeps this presentation's code"
+                          disabled={replacing}
+                          onClick={() => pickReplace(r)}
+                        >
+                          <RefreshCw size={14} />
+                          Replace
+                        </Button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </div>
           </div>
 
@@ -752,6 +864,28 @@ Hello world.
           </div>
         </ScrollReveal>
       </footer>
+
+      {replaceTarget && replaceFile && (
+        <ConfirmReplaceDialog
+          onConfirm={confirmReplace}
+          onClose={() => { setReplaceTarget(null); setReplaceFile(null); }}
+        />
+      )}
+
+      {/* Hidden picker for the recents list' Replace action. Kept outside the
+          list so a cancelled picker simply leaves nothing to confirm. */}
+      <input
+        ref={replaceInputRef}
+        type="file"
+        accept=".pdf,application/pdf"
+        className="hidden"
+        data-testid="recents-replace-input"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) setReplaceFile(file);
+          e.target.value = "";
+        }}
+      />
 
       <MobileNotice />
     </div>

--- a/client/src/pages/Presentation.tsx
+++ b/client/src/pages/Presentation.tsx
@@ -601,6 +601,21 @@ export default function Presentation() {
     navigate("/", { replace: true });
   }, [local, id, navigate]);
 
+  // Authorization for rewriting a synced deck's stored PDF. A logged-in owner
+  // sends their bearer token; a presenter holding only the controller token
+  // (anonymous creation, local-mode server, passphrase-granted controllers)
+  // sends that — the server accepts both, exactly like ending a session.
+  const pdfWriteAuth = useCallback(async (): Promise<Record<string, string>> => {
+    if (authEnabled) {
+      const { data } = await supabase.auth.getSession();
+      const accessToken = data.session?.access_token;
+      if (accessToken) return { Authorization: `Bearer ${accessToken}` };
+    }
+    const { controllerToken } = getSessionAuth(id!);
+    if (!controllerToken) throw new Error("This browser isn't the controller for this presentation");
+    return { "x-controller-token": controllerToken };
+  }, [id]);
+
   // Persist edited speaker notes by writing them back into the PDF as a JSON
   // sidecar (matching presio's format), then swap in the updated document so
   // further edits build on it. Local sessions update IndexedDB; synced ones
@@ -621,20 +636,8 @@ export default function Presentation() {
         const rec = await idbGet(id!);
         if (rec) await idbPut({ ...rec, blob });
       } else {
-        // Synced deck: re-upload to its server copy. Hosted mode authorizes
-        // with the owner's login; local/offline mode has no accounts, so
-        // authorize with the controller token this browser holds.
-        let authHeaders: Record<string, string>;
-        if (authEnabled) {
-          const { data } = await supabase.auth.getSession();
-          const token = data.session?.access_token;
-          if (!token) throw new Error("Please log in again");
-          authHeaders = { Authorization: `Bearer ${token}` };
-        } else {
-          const { controllerToken } = getSessionAuth(id!);
-          if (!controllerToken) throw new Error("This browser isn't the controller for this presentation");
-          authHeaders = { "x-controller-token": controllerToken };
-        }
+        // Synced deck: re-upload to its server copy.
+        const authHeaders = await pdfWriteAuth();
         const form = new FormData();
         form.append("pdf", blob, `${filename || "presentation"}.pdf`);
         const res = await fetch(`/api/sessions/${id}/pdf`, {
@@ -667,7 +670,7 @@ export default function Presentation() {
         setPdfUrl(url);
       }
     },
-    [pdf, local, id, filename]
+    [pdf, local, id, filename, pdfWriteAuth]
   );
 
   // Replace this presentation's PDF with a new file, keeping the session id,
@@ -702,17 +705,7 @@ export default function Presentation() {
         });
         await applyDeckUpdate({ filename, totalSlides });
       } else {
-        let authHeaders: Record<string, string>;
-        if (authEnabled) {
-          const { data } = await supabase.auth.getSession();
-          const token = data.session?.access_token;
-          if (!token) throw new Error("Please log in again");
-          authHeaders = { Authorization: `Bearer ${token}` };
-        } else {
-          const { controllerToken } = getSessionAuth(id!);
-          if (!controllerToken) throw new Error("This browser isn't the controller for this presentation");
-          authHeaders = { "x-controller-token": controllerToken };
-        }
+        const authHeaders = await pdfWriteAuth();
         const form = new FormData();
         form.append("pdf", blob, `${filename}.pdf`);
         form.append("filename", filename);
@@ -735,7 +728,7 @@ export default function Presentation() {
         mode: local ? "local" : "server",
       });
     },
-    [local, id, applyDeckUpdate]
+    [local, id, applyDeckUpdate, pdfWriteAuth]
   );
 
   const onMediaControl = useCallback(

--- a/client/src/pages/Presentation.tsx
+++ b/client/src/pages/Presentation.tsx
@@ -1,19 +1,20 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { useParams, useSearchParams, useNavigate, Link } from "react-router-dom";
 import type { PDFDocumentProxy } from "pdfjs-dist";
+import { getDocument } from "pdfjs-dist";
 import { loadPdf, loadPdfData, renderPage, clearCache } from "@/lib/pdf";
 import { loadDeckInfo, type Deck, type DeckInfo } from "@/lib/deck";
 import { setSlideNotes } from "@/lib/notesAttach";
 import { defaultAudioState, isMutedForRole, type MediaState, type MediaTimeSync, type AudioState } from "@/lib/media";
 import { hasAnyStrokes, parseDrawing, serializeDrawing, type AnnotationsBySlide, type LaserPoint, type Stroke } from "@/lib/annotations";
-import { lsGet, lsSet, annotationsKey } from "@/lib/storage";
+import { lsGet, lsSet, lsRemove, annotationsKey } from "@/lib/storage";
 import { socket } from "@/lib/socket";
 import { startClockSync } from "@/lib/clock";
 import { supabase } from "@/lib/supabaseClient";
 import { authEnabled } from "@/lib/authMode";
 import { getSessionAuth, endSession } from "@/lib/utils";
 import { idbGet, idbPut, idbDelete } from "@/lib/localStore";
-import { track } from "@/lib/analytics";
+import { track, sha256Hex } from "@/lib/analytics";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { ControllerView } from "./ControllerView";
@@ -104,6 +105,11 @@ export default function Presentation() {
 
   stateRef.current = { currentSlide, totalSlides, blanked, showCode, annotations, mediaState, audioState };
 
+  // Mirror of pdfUrl for callbacks that must not re-subscribe the socket
+  // effect when it changes (a deck replace rewrites it on local sessions).
+  const pdfUrlRef = useRef("");
+  pdfUrlRef.current = pdfUrl;
+
   // Persist the controller's drawings across reloads.
   useEffect(() => {
     if (role === "controller") lsSet(annotationsKey(id!), annotations);
@@ -122,6 +128,50 @@ export default function Presentation() {
   const applyClear = useCallback((slide: number) => {
     setAnnotations((prev) => (prev[slide]?.length ? { ...prev, [slide]: [] } : prev));
   }, []);
+
+  // Swap in a replacement deck that arrived over the wire — socket
+  // `deck_updated` for synced sessions or a BroadcastChannel `deck_update`
+  // for local ones. Drawings are dropped wholesale: they are keyed by slide
+  // number and the new document renumbers every slide after an insertion.
+  // Slide clamping needs no extra work here: the deckInfo effect adopts the
+  // new document's page count once it loads.
+  const applyDeckUpdate = useCallback(
+    ({ filename, totalSlides }: { filename: string; totalSlides: number }) => {
+      setFilename(filename);
+      setAnnotations({});
+      lsRemove(annotationsKey(id!));
+      setTotalSlides(totalSlides);
+      setCurrentSlide((slide) => Math.min(Math.max(slide, 1), totalSlides));
+      (async () => {
+        try {
+          if (local) {
+            // Same-browser windows read the fresh record straight from IndexedDB.
+            const rec = await idbGet(id!);
+            if (!rec) return;
+            const bytes = new Uint8Array(await rec.blob.arrayBuffer());
+            const doc = await loadPdfData(bytes);
+            setPdf(doc);
+            const url = URL.createObjectURL(rec.blob);
+            if (localUrlRef.current) URL.revokeObjectURL(localUrlRef.current);
+            localUrlRef.current = url;
+            setPdfUrl(url);
+          } else {
+            // The stored object path doesn't change on replace, so bust any
+            // cached copy along the way before re-fetching.
+            clearCache();
+            const base = pdfUrlRef.current;
+            const busted = `${base}${base.includes("?") ? "&" : "?"}v=${Date.now()}`;
+            const doc = await loadPdf(busted);
+            setPdf(doc);
+          }
+        } catch {
+          // Keep showing the previous deck rather than a broken screen; the
+          // stored row already describes the new one and a reload recovers.
+        }
+      })();
+    },
+    [local, id]
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -224,6 +274,7 @@ export default function Presentation() {
       else if (type === "stroke_undo") applyUndo(payload.slide);
       else if (type === "annotations_clear") applyClear(payload.slide);
       else if (type === "annotations_state") setAnnotations(payload);
+      else if (type === "deck_update") applyDeckUpdate(payload);
       else if (type === "session_ended") navigate("/", { replace: true });
       else if (type === "state_request") {
         // Controller is the source of truth for a local session; reply so a
@@ -393,6 +444,12 @@ export default function Presentation() {
       setAnnotations(bySlide);
     });
 
+    // The controller replaced the deck (server broadcast from the replace
+    // endpoint); reload the new document under the same session.
+    socket.on("deck_updated", (payload: { filename: string; totalSlides: number }) => {
+      applyDeckUpdate(payload);
+    });
+
     // Another window took controllership (same token, e.g. a second tab).
     // Demote this one to a viewer — updating the role param re-runs this
     // effect, so the tab rejoins as a viewer and won't grab control back on
@@ -431,12 +488,13 @@ export default function Presentation() {
       socket.off("stroke_undo");
       socket.off("annotations_clear");
       socket.off("annotations_state");
+      socket.off("deck_updated");
       socket.off("controller_replaced");
       socket.off("error");
       socket.off("session_ended");
       socket.disconnect();
     };
-  }, [id, local, requestedRole, navigate, setSearchParams, applyRole, applyCommit, applyUndo, applyClear]);
+  }, [id, local, requestedRole, navigate, setSearchParams, applyRole, applyCommit, applyUndo, applyClear, applyDeckUpdate]);
 
   // Report the settled role to analytics. The `?role=` query param is already
   // in every tracked URL, but Umami's Pages report keys on the path alone, so
@@ -610,6 +668,74 @@ export default function Presentation() {
       }
     },
     [pdf, local, id, filename]
+  );
+
+  // Replace this presentation's PDF with a new file, keeping the session id,
+  // code, controller token and passphrase. Mirrors saveNotes' local/synced
+  // fork: local decks swap the IndexedDB record in place (nothing uploads);
+  // synced ones re-upload to their stored object and let the server's
+  // deck_updated broadcast drive the document swap on every client.
+  const replacePdf = useCallback(
+    async (file: File) => {
+      if (local === null) return;
+      const buf = await file.arrayBuffer();
+      // Snapshot before pdf.js transfers the buffer away (see Home.upload).
+      const blob = new Blob([buf], { type: "application/pdf" });
+      let sha256: string | undefined;
+      try {
+        sha256 = await sha256Hex(buf);
+      } catch {
+        // No crypto.subtle (plain-http origins): track without a fingerprint.
+      }
+      const doc = await getDocument({ data: new Uint8Array(buf) }).promise;
+      const totalSlides = doc.numPages;
+      doc.destroy();
+      const filename = file.name.replace(/\.pdf$/i, "");
+
+      if (local) {
+        const rec = await idbGet(id!);
+        if (!rec) throw new Error("This presentation is no longer in this browser");
+        await idbPut({ ...rec, blob, filename, totalSlides });
+        channelRef.current?.postMessage({
+          type: "deck_update",
+          payload: { filename, totalSlides },
+        });
+        await applyDeckUpdate({ filename, totalSlides });
+      } else {
+        let authHeaders: Record<string, string>;
+        if (authEnabled) {
+          const { data } = await supabase.auth.getSession();
+          const token = data.session?.access_token;
+          if (!token) throw new Error("Please log in again");
+          authHeaders = { Authorization: `Bearer ${token}` };
+        } else {
+          const { controllerToken } = getSessionAuth(id!);
+          if (!controllerToken) throw new Error("This browser isn't the controller for this presentation");
+          authHeaders = { "x-controller-token": controllerToken };
+        }
+        const form = new FormData();
+        form.append("pdf", blob, `${filename}.pdf`);
+        form.append("filename", filename);
+        const res = await fetch(`/api/sessions/${id}/pdf`, {
+          method: "POST",
+          headers: authHeaders,
+          body: form,
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || "Failed to replace the PDF");
+        }
+      }
+
+      track("deck-replace", {
+        filename,
+        sha256,
+        size: file.size,
+        slides: totalSlides,
+        mode: local ? "local" : "server",
+      });
+    },
+    [local, id, applyDeckUpdate]
   );
 
   const onMediaControl = useCallback(
@@ -821,6 +947,7 @@ export default function Presentation() {
       onEnd={endPresentation}
       onSynced={() => setLocal(false)}
       onSaveNotes={saveNotes}
+      onReplacePdf={replacePdf}
       currentCanvasRef={currentCanvasRef}
       blanked={blanked}
       onBlankToggle={() => {

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -5,7 +5,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { nanoid } from "nanoid";
 import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
 import { isValidHttpsUrl, isValidTotalSlides, MAX_TOTAL_SLIDES } from "../validation.js";
-import { getBearerToken, resolveOptionalUserId, requireUser, safeEqual } from "../auth.js";
+import { getBearerToken, resolveOptionalUserId, safeEqual } from "../auth.js";
 import { isLocalMode } from "../local/mode.js";
 import { clearSessionState, type SocketState } from "../socket.js";
 import { baseUrl } from "../lib/baseUrl.js";
@@ -421,13 +421,10 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
   //     in the room gets `deck_updated` so they reload the new bytes live.
   app.post("/api/sessions/:id/pdf", uploadField("pdf"), async (req, res) => {
     try {
-      // Hosted sessions are owned by a logged-in user; local mode has no auth,
-      // so authorize by the controller token instead (see the claim route).
-      const user = isLocalMode ? null : await requireUser(supabase, req);
-      if (!isLocalMode && !user) {
-        res.status(401).json({ error: "Authentication required" });
-        return;
-      }
+      // Authorized either by the controller token — the same model as ending a
+      // session, so an anonymous presenter (and later agents/CLIs) can rewrite
+      // the deck they control — or, in hosted mode, by the logged-in owner.
+      const user = isLocalMode ? null : await resolveOptionalUserId(supabase, req);
 
       const file = req.file;
       if (!file || file.mimetype !== "application/pdf") {
@@ -444,9 +441,9 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
         res.status(404).json({ error: "Session not found" });
         return;
       }
-      const authorized = isLocalMode
-        ? safeEqual(req.get("x-controller-token") || "", row.controller_token)
-        : row.user_id === user!.id;
+      const authorized =
+        safeEqual(req.get("x-controller-token") || "", row.controller_token) ||
+        (!isLocalMode && !!user && row.user_id === user);
       if (!authorized) {
         res.status(403).json({ error: "Not authorized" });
         return;

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -410,9 +410,15 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
     }
   });
 
-  // Replace a synced presentation's PDF — used to persist edited speaker notes,
-  // which are written back into the PDF as embedded-file sidecars by the client.
-  // Only the authenticated owner may overwrite the stored file.
+  // Replace a synced presentation's PDF in place, keeping its id, code,
+  // controller token and passphrase. Two callers:
+  //
+  //   - Notes editing re-uploads the same document with an embedded sidecar
+  //     written by the client. No filename field → nothing announced.
+  //   - A deck replacement sends `filename`. The row's filename/slide count
+  //     follow the new document, the current slide is clamped into range,
+  //     drawings are dropped (they are keyed by slide number), and everyone
+  //     in the room gets `deck_updated` so they reload the new bytes live.
   app.post("/api/sessions/:id/pdf", uploadField("pdf"), async (req, res) => {
     try {
       // Hosted sessions are owned by a logged-in user; local mode has no auth,
@@ -431,7 +437,7 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
 
       const { data: row, error: rowError } = await supabase
         .from("sessions")
-        .select("id, local, pdf_path, user_id, controller_token")
+        .select("id, local, pdf_path, pdf_url, user_id, controller_token, filename, current_slide")
         .eq("id", req.params.id)
         .single();
       if (rowError || !row) {
@@ -450,6 +456,24 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
         return;
       }
 
+      let totalSlides: number;
+      try {
+        const doc = await getDocument({ data: new Uint8Array(file.buffer) }).promise;
+        totalSlides = doc.numPages;
+        doc.destroy();
+      } catch {
+        res.status(400).json({ error: "The file could not be read as a PDF" });
+        return;
+      }
+      if (!isValidTotalSlides(totalSlides)) {
+        res.status(400).json({ error: `PDF exceeds the ${MAX_TOTAL_SLIDES}-page limit` });
+        return;
+      }
+
+      const rawName = typeof req.body.filename === "string" ? req.body.filename.trim() : "";
+      const newFilename = rawName.replace(/\.pdf$/i, "");
+      const clampedSlide = Math.min(Math.max(row.current_slide ?? 1, 1), totalSlides);
+
       const { error: uploadError } = await supabase.storage
         .from("presentations")
         .upload(row.pdf_path, file.buffer, { contentType: "application/pdf", upsert: true });
@@ -458,7 +482,28 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
         return;
       }
 
-      res.json({ ok: true });
+      const update: Record<string, unknown> = {
+        total_slides: totalSlides,
+        current_slide: clampedSlide,
+      };
+      if (newFilename) update.filename = newFilename;
+      const { error: updateError } = await supabase
+        .from("sessions")
+        .update(update)
+        .eq("id", row.id);
+      if (updateError) {
+        res.status(500).json({ error: "Failed to update session" });
+        return;
+      }
+
+      // A real replacement announces itself; a notes re-save (no filename)
+      // stays silent so viewers aren't forced to re-download identical slides.
+      if (newFilename) {
+        socketState?.annotations.delete(String(req.params.id));
+        io.to(req.params.id).emit("deck_updated", { filename: newFilename, totalSlides });
+      }
+
+      res.json({ ok: true, totalSlides, filename: newFilename || row.filename });
     } catch (err) {
       console.error(err);
       res.status(500).json({ error: "Internal server error" });


### PR DESCRIPTION
## What

Implements #17 — the foundation of epic #5 (update flows). A deck can be swapped for a recompiled file without minting a new session.

- **Recents list** (new): the home page now lists presentations this browser holds, with **Open** and **Replace** actions.
- **Controller**: Replace PDF… in Settings and in the mobile menu.
- Both entry points share one confirm dialog that says what doesn't survive: drawings are cleared (keyed by slide number) and Presio-edited speaker notes are lost.
- Local decks swap the IndexedDB record in place — **nothing uploads**. Synced decks POST to `/api/sessions/:id/pdf` with a `filename` field.

## Server

`POST /api/sessions/:id/pdf` now parses the upload (rejecting unreadable/oversized files with 400), updates `filename` + `total_slides`, clamps `current_slide` into range, clears the session's stored drawings, and broadcasts **`deck_updated`** `{filename, totalSlides}`. Notes re-saves send no filename and stay completely silent on the wire, so viewers are never forced to re-download identical slides.

## Client

A new `deck_updated` handler (socket for synced, BroadcastChannel `deck_update` for local windows) reloads the document — cache-busted refetch for synced decks since the object path is unchanged, fresh IndexedDB record for local ones — resets annotations everywhere, and lets the existing deckInfo effect adopt the new page count and clamp navigation. Session id, code, controller token, passphrase and timer state are untouched by construction.

## Verification

- client build/lint + 30 tests, server tsc + 27 tests, e2e suite — all green
- throwaway smoke harness against the real app + FakeSupabase: notes re-save emits nothing ✓ replace broadcasts once with correct payload ✓ row/storage updated ✓ corrupt bytes → 400 ✓ current_slide 99 clamps to 7 ✓

Closes #17