### PR TITLE
Fix login dialog collapsing into the blurred home nav

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    env:
+      # The gitignored client/.env isn't available in CI; without a Supabase
+      # URL the login UI is compiled out entirely (see lib/authMode.ts). A
+      # placeholder enables the UI for e2e without talking to a real backend
+      # — rendering makes no network requests with it. Set at job level
+      # because Playwright's webServer command rebuilds the client itself.
+      VITE_SUPABASE_URL: https://e2e-placeholder.supabase.co
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -54,12 +61,6 @@ jobs:
           (cd server && npm ci)
       - name: Build client
         run: cd client && npm run build
-        env:
-          # The gitignored client/.env isn't available in CI; without a Supabase
-          # URL the login UI is compiled out entirely (see lib/authMode.ts). A
-          # placeholder enables the UI for e2e without talking to a real
-          # backend — rendering makes no network requests.
-          VITE_SUPABASE_URL: https://e2e-placeholder.supabase.co
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Run E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
           (cd server && npm ci)
       - name: Build client
         run: cd client && npm run build
+        env:
+          # The gitignored client/.env isn't available in CI; without a Supabase
+          # URL the login UI is compiled out entirely (see lib/authMode.ts). A
+          # placeholder enables the UI for e2e without talking to a real
+          # backend — rendering makes no network requests.
+          VITE_SUPABASE_URL: https://e2e-placeholder.supabase.co
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Run E2E tests

--- a/client/src/components/ui/dialog-overlay.tsx
+++ b/client/src/components/ui/dialog-overlay.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card";
+import { createPortal } from "react-dom";
 
 export function DialogOverlay({
   children,
@@ -9,7 +10,11 @@ export function DialogOverlay({
   onClose: () => void;
   maxWidth?: string;
 }) {
-  return (
+  // Portal to <body> so the overlay always covers the viewport: an ancestor
+  // with backdrop-filter (e.g. the home page's blurred nav) would otherwise
+  // become the containing block for this fixed element and collapse it to
+  // that ancestor's box.
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
       onClick={(e) => {
@@ -19,6 +24,7 @@ export function DialogOverlay({
       <Card className={`w-full ${maxWidth} max-h-[90dvh] overflow-y-auto`}>
         <CardContent className="pt-6 space-y-4">{children}</CardContent>
       </Card>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/e2e/login-dialog.spec.ts
+++ b/e2e/login-dialog.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+
+// Regression test: the login dialog opened from the home page nav used to
+// collapse to the nav's box. The nav has backdrop-blur, and an ancestor with a
+// backdrop-filter becomes the containing block for fixed descendants, so the
+// overlay's `fixed inset-0` resolved against the ~64px nav instead of the
+// viewport. DialogOverlay now portals to <body>, which this asserts.
+
+test("login dialog covers the viewport and dims/blurs the page", async ({ page }) => {
+  await page.goto("/");
+  await page.locator("nav").getByRole("button", { name: "Log in", exact: true }).click();
+
+  // The login dialog's DialogOverlay wrapper (scoped via its email input so we
+  // don't match other fixed overlays on the page).
+  const overlay = page.locator("div.fixed.inset-0.z-50", { has: page.locator('input[type="email"]') });
+  await expect(overlay).toBeVisible();
+
+  // Covers the whole viewport, so the card is centered and nothing outside is
+  // clickable/selectable through.
+  const vp = page.viewportSize()!;
+  const box = await overlay.boundingBox();
+  expect(box?.width ?? 0).toBeGreaterThanOrEqual(vp.width * 0.99);
+  expect(box?.height ?? 0).toBeGreaterThanOrEqual(vp.height * 0.99);
+
+  // Dim + blur over the whole page.
+  const styles = await overlay.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return { backdropFilter: cs.backdropFilter, backgroundColor: cs.backgroundColor };
+  });
+  expect(styles.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+  expect(styles.backdropFilter).not.toBe("none");
+
+  // Background content must be behind the overlay, not hit-testable.
+  const heroHit = await page.evaluate(() => {
+    const h1 = document.querySelector(".home2 h1");
+    if (!h1) return null;
+    const r = h1.getBoundingClientRect();
+    return !!document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2)?.closest("div.fixed.inset-0");
+  });
+  expect(heroHit).toBe(true);
+});


### PR DESCRIPTION
## Problem

On the new home page, opening the login dialog produced three symptoms:

- the box rendered at the top of the page, partially cut off
- the background wasn't dimmed or blurred
- background content remained selectable/clickable

## Root cause

The home page `<nav>` has Tailwind's `backdrop-blur`. Per CSS, an ancestor
with a non-none `backdrop-filter` becomes the **containing block for
`position: fixed` descendants**, so `DialogOverlay`'s `fixed inset-0`
resolved against the ~64px nav strip instead of the viewport. One
mechanism, all three symptoms.

Confirmed by measurement before fixing (Playwright against the e2e
harness): overlay bbox was `1280x64 @ (0,0)` pre-fix, `1280x720 @ (0,0)`
post-fix.

## Fix

Portal `DialogOverlay` to `document.body`, so a dialog always covers the
viewport no matter where its caller mounts it. Also fixes the same latent
bug for `AccountControl variant="section"` nested inside the controller
settings dialog (its overlay also carries `backdrop-blur-sm`).

## Test

- `e2e/login-dialog.spec.ts`: asserts full-viewport coverage, dim + blur
  computed styles, and that hero content is hit-tested behind the overlay.
  Red before the fix, green after.
- CI's e2e client build now bakes a placeholder `VITE_SUPABASE_URL`
  (`client/.env` is gitignored), otherwise the login UI is compiled out
  and can't be exercised there. Rendering makes no network calls with it.