### PR TITLE
fix: point the staging deploy at the real stack env file

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -15,8 +15,14 @@ name: Deploy staging
 # Host setup is the same as the PR previews (bare clone at ~/presio.git, deploy
 # key, tailnet) — see the notes at the top of preview.yml. The one addition is
 # the stack .env: docker-compose.staging.yml reuses the production Supabase
-# stack, so it needs the same env file the production compose is run with. Its
-# path comes from the STAGING_ENV_FILE repository variable.
+# stack, so it needs the same env file the production compose is run with — the
+# one beside the production compose at ~/projects/presio. Override it with the
+# STAGING_ENV_FILE repository variable if that ever moves.
+#
+# Staging used to be run by hand from a checkout at ~/projects/presio-staging-src.
+# docker-compose.staging.yml pins `name: presio-staging`, so deploying from this
+# workflow's own worktree manages those same containers; that directory can be
+# removed once this has deployed successfully.
 
 on:
   push:
@@ -55,7 +61,7 @@ jobs:
         env:
           SSH_HOST: ${{ secrets.PREVIEW_SSH_HOST }}
           SSH_USER: ${{ secrets.PREVIEW_SSH_USER }}
-          ENV_FILE: ${{ vars.STAGING_ENV_FILE || '/home/administrator/presio/.env' }}
+          ENV_FILE: ${{ vars.STAGING_ENV_FILE || '/home/administrator/projects/presio/.env' }}
         run: |
           # Variables expand locally; the heredoc is the remote script.
           ssh -o BatchMode=yes -o ConnectTimeout=10 "$SSH_USER@$SSH_HOST" bash -se <<EOF

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -64,6 +64,9 @@ jobs:
           ENV_FILE: ${{ vars.STAGING_ENV_FILE || '/home/administrator/projects/presio/.env' }}
         run: |
           # Variables expand locally; the heredoc is the remote script.
+          # The delimiter is unquoted so $VARs above expand here, which also
+          # means $(...) and backticks run ON THE RUNNER — escape them, and
+          # keep backticks out of the comments below.
           ssh -o BatchMode=yes -o ConnectTimeout=10 "$SSH_USER@$SSH_HOST" bash -se <<EOF
           set -euo pipefail
 
@@ -75,8 +78,8 @@ jobs:
           git -C "$REPO_DIR" fetch --force origin 'refs/heads/staging:refs/remotes/origin/staging'
 
           # Recreate the worktree each time rather than pulling into it: a
-          # rollback moves `staging` backwards, and a detached re-add lands on
-          # the right commit whichever direction the branch moved.
+          # rollback moves the staging branch backwards, and a detached
+          # re-add lands on the right commit whichever direction it moved.
           git -C "$REPO_DIR" worktree remove --force "$WORKTREE" 2>/dev/null || true
           git -C "$REPO_DIR" worktree prune
           git -C "$REPO_DIR" worktree add --detach "$WORKTREE" remotes/origin/staging

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -20,7 +20,9 @@ git push origin main:refs/heads/staging
 #    The default GITHUB_TOKEN will not do — tags it pushes do not trigger
 #    other workflows, so a release tag would land and no image would build.
 gh secret set RELEASE_PLEASE_TOKEN
-gh variable set STAGING_ENV_FILE --body /path/on/host/to/.env
+# STAGING_ENV_FILE is optional: deploy-staging.yml defaults to
+#   /home/administrator/projects/presio/.env
+# which is where the production stack lives. Only set it if that moves.
 
 # 4. Cut the first release. The docs already tell people to pin `:1`, so this
 #    should not wait — that tag does not exist until this runs.


### PR DESCRIPTION
The default in `deploy-staging.yml` was extrapolated from `preview.yml`'s documented layout. Per `docker compose ls` on the host, the production stack actually lives at `/home/administrator/projects/presio`, so its env file is `/home/administrator/projects/presio/.env`.

Also records that staging currently runs from a manual checkout at `~/projects/presio-staging-src`. Since `docker-compose.staging.yml` pins `name: presio-staging`, the workflow's own worktree manages those same containers — the takeover is clean, and that directory can be removed once this has deployed successfully.