### PR TITLE
chore: keep dependabot off runtime-critical major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
     directory: /deploy
     schedule:
       interval: monthly
+    ignore:
+      # The Node major is the runtime companies self-host. Moving it changes
+      # the libc, the OpenSSL, and the better-sqlite3 prebuild ABI all at once,
+      # so it is a deliberate, tested upgrade — not a PR that appears one
+      # morning. Patch and minor bumps (security fixes) still come through.
+      - dependency-name: node
+        update-types: [version-update:semver-major]
 
   - package-ecosystem: npm
     directory: /client
@@ -34,6 +41,15 @@ updates:
     groups:
       server-minor-patch:
         update-types: [minor, patch]
+    ignore:
+      # Same reasoning as the base image: these two decide whether existing
+      # deployments keep working. better-sqlite3 owns the local-mode database
+      # (and its native ABI), pdfjs-dist owns rendering. Major bumps here are
+      # planned work with the upgrade smoke test as the gate.
+      - dependency-name: better-sqlite3
+        update-types: [version-update:semver-major]
+      - dependency-name: pdfjs-dist
+        update-types: [version-update:semver-major]
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
The Dependabot config added in #33 opened 12 PRs on its first run, including three majors on the components a self-hosted deployment can least afford a surprise in:

- `node` 20 → **26** (the base image — changes libc, OpenSSL, and the `better-sqlite3` prebuild ABI at once)
- `better-sqlite3` 11 → **13** (owns local mode's database and its native ABI)
- `pdfjs-dist` 5 → **6** (owns rendering)

These should be planned upgrades gated on the new upgrade smoke test, not a PR that appears one morning. This ignores **major** updates for those three only — patch and minor bumps, including security fixes, still come through, and everything else is unchanged.

Does not close the existing PRs (#34, #36, #37); they can be closed or taken deliberately.