### PR TITLE
fix: document a verification command that actually works

### DIFF
--- a/.github/workflows/publish-local-image.yml
+++ b/.github/workflows/publish-local-image.yml
@@ -84,6 +84,7 @@ jobs:
         run: deploy/smoke-test.sh presio-local:smoke ${{ env.IMAGE }}:latest
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -101,3 +102,15 @@ jobs:
           sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # BuildKit's `provenance:` above attaches an attestation to the image in
+      # the registry; this publishes a Sigstore-signed one to GitHub's own
+      # attestation store as well. They are different mechanisms with different
+      # verification paths, and only this one is discoverable with
+      # `gh attestation verify` — which is the check most people reach for.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,13 @@ address is a deployment choice rather than a vulnerability.
 Published images carry a signed build provenance attestation:
 
 ```bash
-gh attestation verify --owner benedict-armstrong \
+docker buildx imagetools inspect ghcr.io/benedict-armstrong/presio-local:1 \
+  --format '{{ json .Provenance }}'   # how and from what commit it was built
+docker buildx imagetools inspect ghcr.io/benedict-armstrong/presio-local:1 \
+  --format '{{ json .SBOM }}'         # what is inside it
+
+# Releases from v1.2.0 onward also carry a Sigstore-signed attestation in
+# GitHub's own store, which the CLI checks against this repository:
+gh attestation verify --repo benedict-armstrong/presio \
   oci://ghcr.io/benedict-armstrong/presio-local:1
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -140,7 +140,14 @@ Every published image carries a signed build provenance attestation and an
 SBOM. Verify a build really came from this repository with:
 
 ```bash
-gh attestation verify --owner benedict-armstrong \
+docker buildx imagetools inspect ghcr.io/benedict-armstrong/presio-local:1 \
+  --format '{{ json .Provenance }}'   # how and from what commit it was built
+docker buildx imagetools inspect ghcr.io/benedict-armstrong/presio-local:1 \
+  --format '{{ json .SBOM }}'         # what is inside it
+
+# Releases from v1.2.0 onward also carry a Sigstore-signed attestation in
+# GitHub's own store, which the CLI checks against this repository:
+gh attestation verify --repo benedict-armstrong/presio \
   oci://ghcr.io/benedict-armstrong/presio-local:1
 ```
 


### PR DESCRIPTION
The verification command shipped in #33 does not work. I ran it against the freshly published v1.1.0 image:

```
$ gh attestation verify --owner benedict-armstrong oci://ghcr.io/.../presio-local:1
Error: HTTP 404 (https://api.github.com/orgs/benedict-armstrong/attestations/sha256:4617d2d...)
```

Two separate mistakes:

1. **`--owner` queries the *orgs* API**, and this is a user account. `--repo` is the right flag — but it 404s too, which is the real problem.
2. **`provenance: mode=max` and `gh attestation verify` are different mechanisms.** BuildKit attaches an in-toto attestation to the image *in the registry*; `gh attestation verify` queries GitHub's own attestation store, which only `actions/attest-build-provenance` populates. Documenting one and implementing the other meant the instruction could never have worked.

The provenance and SBOM themselves are fine — v1.1.0 carries both, one attestation manifest per platform, and the provenance even records `"build-arg:APP_VERSION": "1.1.0"`.

### Changes

- Docs now show the `docker buildx imagetools inspect` commands for provenance and SBOM. **Verified against the published v1.1.0 image**, not written from memory this time.
- Adds `actions/attest-build-provenance` so `gh attestation verify` also works, since that is the check most people reach for. Noted in the docs as applying from v1.2.0 onward, because v1.1.0 predates it.

Worth a real release to confirm the attestation step end to end — v1.1.0 cannot be retrofitted.