### PR TITLE
ci: make presio.git/worktree host paths required repo variables

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -12,12 +12,13 @@ name: Deploy staging
 #
 # — which lands here through the `push` trigger below and redeploys that commit.
 #
-# Host setup is the same as the PR previews (bare clone at ~/presio.git, deploy
-# key, tailnet) — see the notes at the top of preview.yml. The one addition is
-# the stack .env: docker-compose.staging.yml reuses the production Supabase
-# stack, so it needs the same env file the production compose is run with — the
-# one beside the production compose at ~/projects/presio. Override it with the
-# STAGING_ENV_FILE repository variable if that ever moves.
+# Host setup is the same as the PR previews (bare clone, deploy key, tailnet)
+# — see the notes at the top of preview.yml. REPO_DIR and WORKTREE below are
+# overridable via repo variables, same as preview.yml's REPO_DIR/PREVIEW_DIR.
+# The one addition is the stack .env: docker-compose.staging.yml reuses the
+# production Supabase stack, so it needs the same env file the production
+# compose is run with. Override it with the STAGING_ENV_FILE repository
+# variable if that ever moves.
 #
 # Staging used to be run by hand from a checkout at ~/projects/presio-staging-src.
 # docker-compose.staging.yml pins `name: presio-staging`, so deploying from this
@@ -39,8 +40,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  REPO_DIR: /home/administrator/presio.git
-  WORKTREE: /home/administrator/presio-staging
+  # No default: an unset repo variable must fail the run loudly rather than
+  # silently resolve to an empty string. Set REPO_DIR / STAGING_WORKTREE
+  # under Settings → Secrets and variables → Actions → Variables.
+  REPO_DIR: ${{ vars.REPO_DIR }}
+  WORKTREE: ${{ vars.STAGING_WORKTREE }}
 
 jobs:
   deploy:
@@ -49,6 +53,15 @@ jobs:
       name: staging
       url: https://staging.presio.xyz
     steps:
+      - name: Check required repo variables
+        run: |
+          missing=()
+          [ -z "$REPO_DIR" ] && missing+=(REPO_DIR)
+          [ -z "$WORKTREE" ] && missing+=(STAGING_WORKTREE)
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing repo variables: ${missing[*]} — set them under Settings → Secrets and variables → Actions → Variables"
+            exit 1
+          fi
       - uses: actions/checkout@v7
       - uses: ./.github/actions/host-ssh
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,9 +26,12 @@ name: PR preview
 #      SSL doesn't cover two-level names; an orange-clouded wildcard A record
 #      *.presio.xyz → the host routes them, and the proxy serves a Cloudflare
 #      Origin CA default certificate (*.presio.xyz) back to the edge — no ACME.
-#   2. Bare clone + previews dir + deploy keypair (all under $HOME, no sudo):
-#        git clone --bare https://github.com/benedict-armstrong/presio.git ~/presio.git
-#        mkdir -p ~/presio-previews
+#   2. Bare clone + previews dir + deploy keypair. REPO_DIR / PREVIEW_DIR
+#      have no default — set them as repo variables (Settings → Secrets and
+#      variables → Actions → Variables) or the workflow fails loudly before
+#      it touches the host:
+#        git clone --bare https://github.com/benedict-armstrong/presio.git "$REPO_DIR"
+#        mkdir -p "$PREVIEW_DIR"
 #        ssh-keygen -t ed25519 -f ~/presio-preview-key -N '' -C presio-previews
 #      authorized_keys entry is restricted to tailnet source IPs:
 #        from="100.64.0.0/10,fd7a:115c:a1e0::/48",no-agent-forwarding,...
@@ -42,7 +45,7 @@ name: PR preview
 #
 # If a `closed` event is ever missed (workflow disabled, Actions outage), the
 # leftover preview can be dropped by hand:
-#   docker compose -p presio-pr-<n> -f ~/presio-previews/docker-compose.preview.yml down -v
+#   docker compose -p presio-pr-<n> -f "$PREVIEW_DIR/docker-compose.preview.yml" down -v
 
 on:
   pull_request:
@@ -68,8 +71,12 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REPO_DIR: /home/administrator/presio.git # bare clone the workflow fetches PR refs into
-  PREVIEW_DIR: /home/administrator/presio-previews # compose file copy + per-PR worktrees
+  # Repo variables (Settings → Secrets and variables → Actions → Variables),
+  # no default: a host-side path change is a variable edit, not a code
+  # change, and an unset variable must fail loudly rather than silently
+  # resolve to an empty string.
+  REPO_DIR: ${{ vars.REPO_DIR }} # bare clone the workflow fetches PR refs into
+  PREVIEW_DIR: ${{ vars.PREVIEW_DIR }} # compose file copy + per-PR worktrees
   PREVIEW_LABEL: preview
 
 jobs:
@@ -188,6 +195,15 @@ jobs:
     permissions:
       pull-requests: write # sticky preview-URL comment
     steps:
+      - name: Check required repo variables
+        run: |
+          missing=()
+          [ -z "$REPO_DIR" ] && missing+=(REPO_DIR)
+          [ -z "$PREVIEW_DIR" ] && missing+=(PREVIEW_DIR)
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing repo variables: ${missing[*]} — set them under Settings → Secrets and variables → Actions → Variables"
+            exit 1
+          fi
       - uses: actions/checkout@v7
       - uses: ./.github/actions/host-ssh
         with:
@@ -269,6 +285,15 @@ jobs:
     permissions:
       pull-requests: write # update the sticky comment
     steps:
+      - name: Check required repo variables
+        run: |
+          missing=()
+          [ -z "$REPO_DIR" ] && missing+=(REPO_DIR)
+          [ -z "$PREVIEW_DIR" ] && missing+=(PREVIEW_DIR)
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing repo variables: ${missing[*]} — set them under Settings → Secrets and variables → Actions → Variables"
+            exit 1
+          fi
       - uses: actions/checkout@v7
       - uses: ./.github/actions/host-ssh
         with:


### PR DESCRIPTION
Replaces the hardcoded `~/presio.git`, `~/presio-previews`, `~/presio-staging` host paths in `preview.yml` / `deploy-staging.yml` with repo variables (`REPO_DIR`, `PREVIEW_DIR`, `STAGING_WORKTREE`), same pattern as the existing `STAGING_ENV_FILE` variable.

No default: each job checks the variables are set and fails loudly before touching the host if not.

Needed because the bare repo is moving from `~/presio.git` to `~/projects/presio/presio.git` on the deploy host — this PR must merge (and the repo variables below must be set) before that move happens, or the next staging deploy / PR preview fails.

Repo variables to set before merging:
- `REPO_DIR` = `/home/administrator/projects/presio/presio.git`
- `PREVIEW_DIR` = `/home/administrator/projects/presio/presio-previews`
- `STAGING_WORKTREE` = `/home/administrator/projects/presio/presio-staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)