### PR TITLE
ci: fix attestation permission and harden worktree recreation

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -102,6 +102,10 @@ jobs:
           # re-add lands on the right commit whichever direction it moved.
           git -C "$REPO_DIR" worktree remove --force "$WORKTREE" 2>/dev/null || true
           git -C "$REPO_DIR" worktree prune
+          # Belt-and-braces: a directory left behind by a crashed or
+          # overlapping run (not a registered worktree, so the remove above
+          # is a no-op) would otherwise make `add` fail with "already exists".
+          rm -rf "$WORKTREE"
           git -C "$REPO_DIR" worktree add --detach "$WORKTREE" remotes/origin/staging
 
           cd "$WORKTREE"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -114,7 +114,7 @@ jobs:
           # Baked into the image so /healthz reports the deployed commit, which
           # is what the verify step below waits for.
           APP_VERSION="staging-\$SHA" \
-            docker compose --env-file "$ENV_FILE" -f docker-compose.staging.yml up -d --build
+            docker compose --env-file "$ENV_FILE" -f docker-compose.staging.yml up -d --build --remove-orphans
           docker image prune -f >/dev/null
           EOF
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,7 +45,7 @@ name: PR preview
 #
 # If a `closed` event is ever missed (workflow disabled, Actions outage), the
 # leftover preview can be dropped by hand:
-#   docker compose -p presio-pr-<n> -f "$PREVIEW_DIR/docker-compose.preview.yml" down -v
+#   docker compose -p presio-pr-<n> -f "$PREVIEW_DIR/docker-compose.preview.yml" down -v --rmi local
 
 on:
   pull_request:
@@ -246,7 +246,7 @@ jobs:
 
           cd "$PREVIEW_DIR"
           BUILD_CONTEXT="$PREVIEW_DIR/pr-$PR" PR_NUMBER="$PR" \
-            docker compose -p "presio-pr-$PR" -f docker-compose.preview.yml up -d --build
+            docker compose -p "presio-pr-$PR" -f docker-compose.preview.yml up -d --build --remove-orphans
           docker image prune -f >/dev/null
           EOF
 
@@ -316,11 +316,15 @@ jobs:
           set -euo pipefail
           if [ -f "$PREVIEW_DIR/docker-compose.preview.yml" ]; then
             cd "$PREVIEW_DIR"
+            # --rmi local drops the image compose built for this PR too —
+            # without it, every closed PR leaves a several-hundred-MB image
+            # behind forever (down only touches containers/networks/volumes).
             PR_NUMBER="$PR" docker compose -p "presio-pr-$PR" \
-              -f docker-compose.preview.yml down -v --remove-orphans || true
+              -f docker-compose.preview.yml down -v --remove-orphans --rmi local || true
           else
             docker rm -f "presio-pr-$PR-preview-1" 2>/dev/null || true
             docker volume rm "presio-pr-${PR}_data" 2>/dev/null || true
+            docker rmi "presio-pr-$PR-preview" 2>/dev/null || true
           fi
           git -C "$REPO_DIR" worktree remove --force "$PREVIEW_DIR/pr-$PR" 2>/dev/null || true
           git -C "$REPO_DIR" worktree prune

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -226,6 +226,10 @@ jobs:
 
           git -C "$REPO_DIR" worktree remove --force "$PREVIEW_DIR/pr-$PR" 2>/dev/null || true
           git -C "$REPO_DIR" worktree prune
+          # Belt-and-braces: a directory left behind by a crashed or
+          # overlapping run (not a registered worktree, so the remove above
+          # is a no-op) would otherwise make `add` fail with "already exists".
+          rm -rf "$PREVIEW_DIR/pr-$PR"
           git -C "$REPO_DIR" worktree add --detach "$PREVIEW_DIR/pr-$PR" "remotes/origin/pr-$PR"
 
           # Always take the compose file from main, never from the PR: the PR

--- a/.github/workflows/publish-local-image.yml
+++ b/.github/workflows/publish-local-image.yml
@@ -42,6 +42,7 @@ jobs:
       contents: read
       packages: write
       id-token: write # keyless signing / provenance attestations
+      attestations: write # persist the provenance attestation to GitHub's store
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v4


### PR DESCRIPTION
- \`publish-local-image.yml\` was missing the \`attestations: write\` permission, so every publish failed at the "Attest build provenance" step with "Resource not accessible by integration".
- \`deploy-staging.yml\` / \`preview.yml\`: \`git worktree add\` failed if the target directory existed but wasn't a registered worktree (e.g. left behind by a crashed or overlapping run) — \`worktree remove --force\` is a no-op in that case. Added an \`rm -rf\` fallback before \`add\` so redeploys self-heal.

Verified on this host: manual \`workflow_dispatch\` of Deploy staging succeeded end-to-end (staging now serving the deployed commit), and \`/preview\` + \`/preview stop\` on a real PR deployed and tore down cleanly.