### PR TITLE
Drop the in-app HTTP rate limiter in favour of the Cloudflare edge

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -122,6 +122,29 @@ resolves, Traefik fetches certificates and serves:
 
 Watch certificate issuance / routing with `docker compose -p proxy logs -f traefik`.
 
+## What sits in front of the app (production)
+
+Two hops, and the count matters — it is what `trust proxy` is set to:
+
+```
+visitor ──▶ Cloudflare edge ──▶ Traefik ──▶ presio:3001
+                                └── app.set("trust proxy", 1) counts from here
+```
+
+Traefik runs without `forwardedHeaders.trustedIPs`, so it **overwrites**
+`X-Forwarded-For` with its own peer rather than appending to Cloudflare's. The
+app therefore sees the Cloudflare edge as `req.ip`, and raising the hop count
+would not change that — the visitor's real address survives only in
+`Cf-Connecting-Ip`. `trust proxy` is kept for `req.protocol`, which `baseUrl()`
+needs so generated links come out `https://`.
+
+Both Traefik entrypoints refuse any source outside Cloudflare's published
+ranges (`proxy/certs/dynamic/cfonly.yml`, applied as an entrypoint-default
+middleware so every router is covered), and the host firewall is configured to
+the same effect. That is what makes `Cf-Connecting-Ip` trustworthy at the edge:
+it is an ordinary header, so it is only meaningful while the edge is
+unavoidable.
+
 ## Rate limiting
 
 The app does **no HTTP rate limiting of its own** — that belongs on whatever

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -122,6 +122,22 @@ resolves, Traefik fetches certificates and serves:
 
 Watch certificate issuance / routing with `docker compose -p proxy logs -f traefik`.
 
+## Rate limiting
+
+The app does **no HTTP rate limiting of its own** — that belongs on whatever
+proxy or CDN fronts it, which is the only layer that can see the real client
+address. Behind two hops (a CDN, then Traefik) the address the app observes is
+the CDN's edge, so a limiter here would put every visitor behind a given edge
+into one shared bucket; the real address arrives only in a vendor header such
+as `Cf-Connecting-Ip`, which is forgeable by anyone able to reach the origin
+directly. presio.xyz limits at the Cloudflare edge and refuses non-Cloudflare
+traffic at the origin. If you self-host without a CDN in front, add a limit on
+your own proxy — Traefik's own `ratelimit` middleware is enough.
+
+Independent of this, `join_session` over Socket.IO is throttled per connection
+in `server/socket.ts`, because its reply reveals whether a 6-character join code
+exists. That throttle is part of the app and needs no configuration.
+
 ## Versions and upgrading
 
 Releases are `v*` git tags, published as container tags on

--- a/server/app.ts
+++ b/server/app.ts
@@ -3,7 +3,6 @@ import fs from "fs";
 import * as Sentry from "@sentry/node";
 import cors from "cors";
 import helmet from "helmet";
-import rateLimit from "express-rate-limit";
 import path from "path";
 import { fileURLToPath } from "url";
 import type { Server } from "socket.io";
@@ -30,11 +29,12 @@ export function createApp({ supabase, io, socketState }: AppDeps): express.Expre
   const app = express();
 
   // Exactly one reverse-proxy hop (Traefik) sits in front in production, so
-  // trust one level of X-Forwarded-For. Without this every request appears to
-  // come from the proxy's IP and the rate limiter throttles all users as one;
-  // trusting more hops would let clients spoof their IP via the header. Local
-  // mode has no proxy in front, so set TRUST_PROXY=false there — otherwise an
-  // unproxied client could spoof its rate-limit IP via the header itself.
+  // trust one level of X-Forwarded-*. This is what makes `req.protocol` report
+  // the scheme the *browser* used rather than the plain HTTP of the last hop —
+  // baseUrl() builds handoff links and canonical tags from it, so without this
+  // every generated link would come out `http://`. Trusting more hops would let
+  // a client dictate those headers itself. Local mode has no proxy in front, so
+  // set TRUST_PROXY=false there.
   app.set("trust proxy", process.env.TRUST_PROXY === "false" ? false : 1);
 
   const allowedOrigins = getAllowedOrigins();
@@ -67,22 +67,23 @@ export function createApp({ supabase, io, socketState }: AppDeps): express.Expre
   );
   app.use(cors({ origin: corsOrigin }));
 
-  // Throttle the JSON API to blunt brute-force (passphrase auth) and abuse.
-  // Generous enough not to interfere with normal presenter/viewer flows — note
-  // that live presenting (slide changes, laser, drawing) runs over Socket.IO,
-  // not HTTP, so none of it is counted here; see socket.ts for that side.
+  // There is deliberately no HTTP rate limiter here. Rate limiting belongs at
+  // the edge: the app used to key one on `req.ip`, but with Cloudflare and then
+  // Traefik in front, that address is the Cloudflare edge — so every visitor
+  // behind a given edge shared one budget and a single busy user could throttle
+  // strangers. The real client address only ever arrives in `Cf-Connecting-Ip`,
+  // which is an ordinary spoofable header, so trusting it here would only be
+  // sound because the origin refuses non-Cloudflare traffic — i.e. the edge is
+  // already the enforcement point. Limiting there instead of here is both
+  // correct per-visitor and one moving part fewer.
   //
-  // Mounted above the body parsers on purpose: /mcp accepts a 70mb body, and
-  // parsing before throttling would buffer all of it into memory for a request
-  // that is about to be rejected anyway.
-  //
-  // Separate instances, so /api and /mcp get separate budgets. A single shared
-  // instance meant a presenter's ordinary API traffic could exhaust the quota
-  // for that IP's agent calls (and vice versa) — one busy path locked out the
-  // other even though neither was close to abusive on its own.
-  const limiterOpts = { windowMs: 15 * 60 * 1000, limit: 300, standardHeaders: true, legacyHeaders: false } as const;
-  app.use("/api", rateLimit({ ...limiterOpts }));
-  app.use("/mcp", rateLimit({ ...limiterOpts }));
+  // Deployments that do NOT sit behind Cloudflare (self-hosted per
+  // deploy/README.md, or PRESIO_MODE=local) therefore have no HTTP rate
+  // limiting of their own — put it on whatever proxy or CDN fronts them.
+  // Note this is not brute-force protection either way: the shared-control
+  // passphrase is 8 characters over a 32-symbol alphabet (~2^40), and live
+  // presenting (slide changes, laser, drawing) runs over Socket.IO rather than
+  // HTTP, so it never passed through the limiter at all — see socket.ts.
 
   // The MCP tools (present_pdf / check_pdf) take the PDF base64-encoded inside
   // the JSON-RPC body, so /mcp needs a body limit in the same league as the
@@ -108,8 +109,9 @@ export function createApp({ supabase, io, socketState }: AppDeps): express.Expre
     res.status(status).json({ error: message });
   });
 
-  // Liveness probe for uptime monitoring (Uptime Kuma). Outside /api so it's
-  // not rate-limited, and intentionally cheap — it doesn't touch the DB.
+  // Liveness probe for uptime monitoring (Uptime Kuma). Outside /api so a probe
+  // never counts against anything the edge meters, and intentionally cheap — it
+  // doesn't touch the DB.
   app.get("/healthz", (_req, res) => {
     // `version` is here rather than on its own route so that the one URL
     // people already curl when a self-hosted deployment misbehaves also

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,6 @@
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
-        "express-rate-limit": "^8.6.2",
         "helmet": "^8.3.0",
         "multer": "^2.1.1",
         "nanoid": "^6.0.1",
@@ -1883,6 +1882,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,6 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
-    "express-rate-limit": "^8.6.2",
     "helmet": "^8.3.0",
     "multer": "^2.1.1",
     "nanoid": "^6.0.1",


### PR DESCRIPTION
Closes #16. Depends on #6.

## Why

The limiter keyed on `req.ip`. Cloudflare and then Traefik sit in front, so that address is the **Cloudflare edge**, not the visitor — everyone behind a given edge shared one 300/15min budget, and one busy user could throttle strangers.

Raising `trust proxy` would **not** have fixed it. The production Traefik runs without `forwardedHeaders.trustedIPs`, so it *overwrites* `X-Forwarded-For` with its own peer instead of appending to Cloudflare's. Verified against a local replication of the same Traefik version and flags:

| request | what Express saw (`req.ip`) |
| --- | --- |
| plain | proxy peer |
| client sends `X-Forwarded-For: 203.0.113.99` | proxy peer (client value discarded) |
| client sends a 2-entry XFF | proxy peer (whole chain discarded) |
| client sends `CF-Connecting-IP` | **passed through untouched** |

So the real client address survives only in `Cf-Connecting-Ip` — an ordinary header anyone reaching the origin directly can forge. Keying on it is sound only because the origin refuses non-Cloudflare traffic, at which point the edge is already the enforcement point. Limiting there is both correct per-visitor and one moving part fewer.

## What changed

- Removed both `express-rate-limit` instances (`/api`, `/mcp`) and the dependency.
- Kept `app.set("trust proxy", …)` — `req.protocol` feeds `baseUrl()`, so without it every handoff link and canonical tag would come out `http://`.
- Documented in `deploy/README.md` that self-hosters without a CDN should limit at their own proxy.
- Untouched: the per-connection `join_session` token bucket in `server/socket.ts`, which guards the join-code enumeration oracle and never keyed on IP.

## Before merging

**Draft on purpose** — two things must land first, neither of which is in this repo:

1. A Cloudflare rate-limiting rule for presio.xyz. Until it exists, merging + deploying leaves production with no HTTP rate limiting at all.
2. The origin lockdown from #6 actually enforced. It currently rests on a host firewall that no checkout can verify.

Brute force is not the concern either way: the shared-control passphrase is 8 chars over a 32-symbol alphabet (~2^40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)