### PR TITLE
feat: add 'Open a Presio project in Overleaf' button on about and landing pages

### DIFF
--- a/client/src/lib/overleaf.ts
+++ b/client/src/lib/overleaf.ts
@@ -1,0 +1,6 @@
+// One-click entry into Overleaf: seeds a project from the presio-latex-package
+// "overleaf-starter" rolling release, whose asset URL never changes (see
+// benedict-armstrong/presio#14). Kept here so every page that advertises the
+// button points at the same URL.
+export const OPEN_IN_OVERLEAF_URL =
+  "https://www.overleaf.com/docs?snip_uri=https://github.com/benedict-armstrong/presio-latex-package/releases/download/overleaf-starter/presio-starter.zip";

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CodeBlock } from "@/components/CodeBlock";
+import { OPEN_IN_OVERLEAF_URL } from "@/lib/overleaf";
 
 const PACKAGE_URL = "https://github.com/benedict-armstrong/presio-typst-package";
 
@@ -205,6 +206,20 @@ Hello world.
 \\speakernote{Remember to mention the demo.}
 `} />
             </div>
+          </div>
+
+          <div className="rounded-md border px-3 py-2.5 text-sm text-muted-foreground space-y-2">
+            <p className="text-foreground font-medium">LaTeX without installing TeX</p>
+            <p>
+              Open a ready-made Presio deck in Overleaf — <code className="bg-muted px-1 rounded text-xs">main.tex</code>{" "}
+              and <code className="bg-muted px-1 rounded text-xs">presio.sty</code> preloaded, with speaker notes and
+              media already wired up to compile on the first pass.
+            </p>
+            <Button variant="outline" size="sm" asChild>
+              <a href={OPEN_IN_OVERLEAF_URL} target="_blank" rel="noopener noreferrer">
+                Open a Presio project in Overleaf
+              </a>
+            </Button>
           </div>
 
           <div className="rounded-md border px-3 py-2.5 text-sm text-muted-foreground">

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -15,12 +15,11 @@ import { lsRemove, annotationsKey } from "@/lib/storage";
 import { track, sha256Hex } from "@/lib/analytics";
 import { loadExternalPdfMeta, createExternalSession } from "@/lib/externalSession";
 import { supabase } from "@/lib/supabaseClient";
+import { OPEN_IN_OVERLEAF_URL } from "@/lib/overleaf";
 import "@/lib/pdf"; // ensure pdf.js worker is configured
 
 const TYPST_PACKAGE_URL = "https://github.com/benedict-armstrong/presio-typst-package";
 const LATEX_PACKAGE_URL = "https://github.com/benedict-armstrong/presio-latex-package";
-const OVERLEAF_EXAMPLE_URL =
-  "https://www.overleaf.com/docs?snip_uri[]=https://raw.githubusercontent.com/benedict-armstrong/presio-latex-package/main/starter/main.tex&snip_uri[]=https://raw.githubusercontent.com/benedict-armstrong/presio-latex-package/main/presio.sty&snip_uri[]=https://raw.githubusercontent.com/benedict-armstrong/presio-latex-package/main/starter/clip.gif&snip_uri[]=https://raw.githubusercontent.com/benedict-armstrong/presio-latex-package/main/starter/poster.png&snip_name[]=main.tex&snip_name[]=presio.sty&snip_name[]=clip.gif&snip_name[]=poster.png&engine=pdflatex";
 
 const TYPST_EXAMPLE_PDF_URL =
   "https://raw.githubusercontent.com/benedict-armstrong/presio-typst-package/main/examples/plain/example.pdf";
@@ -946,8 +945,8 @@ Hello world.
               />
               <div className="mt-auto flex flex-wrap gap-2 pt-4">
                 <Button variant="outline" asChild>
-                  <a href={OVERLEAF_EXAMPLE_URL} target="_blank" rel="noopener noreferrer">
-                    Open example in Overleaf
+                  <a href={OPEN_IN_OVERLEAF_URL} target="_blank" rel="noopener noreferrer">
+                    Open a Presio project in Overleaf
                   </a>
                 </Button>
                 <Button variant="outline" disabled={exampleBusy !== null} onClick={() => openExample("latex")}>


### PR DESCRIPTION
Adds a one-click route from the site to a working LaTeX deck in Overleaf, per #18.

- `client/src/lib/overleaf.ts` defines the Overleaf docs URL (`https://www.overleaf.com/docs?snip_uri=<starter zip>`) once, using the stable `overleaf-starter` rolling release of presio-latex-package confirmed working in #14.
- Landing page: the Overleaf button in the LaTeX integrations card now reads "Open a Presio project in Overleaf" and seeds an Overleaf project from the hosted starter zip (`main.tex`, `presio.sty`, media wired up), replacing the previous per-file raw-URL seeding.
- About page: new bordered callout ("LaTeX without installing TeX") with an outline button, styled like the existing boxed rows and sitting above the /check box.

The manual route (copying `presio.sty` next to your `.tex`) is untouched. Button rows use `flex-wrap`/auto width so they stack cleanly on mobile and desktop.

Checks: `npm run lint` (only pre-existing errors in untouched files), `tsc -b` clean, `npm test` — 30/30 client unit tests pass.

Closes #18