### PR TITLE
feat: let local deploys rewrite share links to the machine's LAN address

### DIFF
--- a/client/src/components/LanAddressField.tsx
+++ b/client/src/components/LanAddressField.tsx
@@ -1,23 +1,54 @@
 import { useState } from "react";
-import { needsLanOverride } from "@/lib/joinUrl";
+import { needsLanOverride, type LanStatus } from "@/lib/joinUrl";
 
-// Editable field for this machine's LAN address, shown on share surfaces only
-// when Presio is being viewed over localhost/loopback (see lib/joinUrl.ts).
-// Every change rewrites the join links and QR codes on screen immediately; the
-// value persists across sessions. Renders nothing when the page was opened by
-// a host other devices can already reach — hosted deploys are untouched.
+// The manual escape hatch for the address other devices join at.
+//
+// It is deliberately not the primary path: the server resolves the address on
+// its own (see lib/joinUrl.ts), so in the ordinary local deployment this
+// collapses to a single line confirming where people will join, and the input
+// only opens if the presenter asks for it. It presents itself when the resolved
+// address failed its reachability check, or when no address could be resolved
+// at all — the bridged-container case, where nothing inside the container can
+// see the host's network.
+//
+// Renders nothing when the page was opened on a host other devices can already
+// reach, so hosted deploys never show it.
 
 export function LanAddressField({
   value,
   onChange,
+  status,
+  origin,
 }: {
   value: string;
   onChange: (address: string) => void;
+  status: LanStatus;
+  origin: string;
 }) {
-  // Mounted once per share surface; deciding at mount is enough because
-  // window.location.hostname can't change without a navigation.
+  // Deciding at mount is enough because window.location.hostname can't change
+  // without a navigation.
   const [visible] = useState(() => needsLanOverride());
+  const [expanded, setExpanded] = useState(false);
   if (!visible) return null;
+
+  // Don't flash a warning during the round-trip that would resolve it.
+  if (status === "checking" && !expanded) return null;
+
+  if (status === "ok" && !expanded) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Other devices join at <span className="font-mono">{origin}</span>{" "}
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="underline underline-offset-2 hover:text-foreground"
+        >
+          Change
+        </button>
+      </p>
+    );
+  }
+
   return (
     <div className="space-y-1">
       <label htmlFor="presio-lan-address" className="text-xs font-medium text-muted-foreground">
@@ -35,6 +66,19 @@ export function LanAddressField({
         onChange={(e) => onChange(e.target.value)}
         className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       />
+      {status === "unreachable" && (
+        <p className="text-xs text-amber-600 dark:text-amber-500">
+          Nothing answered at <span className="font-mono">{origin}</span> from this machine. Check
+          the address, or whether a firewall is blocking the port.
+        </p>
+      )}
+      {status === "unavailable" && (
+        <p className="text-xs text-muted-foreground">
+          Presio couldn&apos;t work out this machine&apos;s address — it&apos;s running in a
+          container with its own network. Enter the address here, or set{" "}
+          <span className="font-mono">PRESIO_PUBLIC_HOST</span> on the container.
+        </p>
+      )}
     </div>
   );
 }

--- a/client/src/components/LanAddressField.tsx
+++ b/client/src/components/LanAddressField.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { needsLanOverride } from "@/lib/joinUrl";
+
+// Editable field for this machine's LAN address, shown on share surfaces only
+// when Presio is being viewed over localhost/loopback (see lib/joinUrl.ts).
+// Every change rewrites the join links and QR codes on screen immediately; the
+// value persists across sessions. Renders nothing when the page was opened by
+// a host other devices can already reach — hosted deploys are untouched.
+
+export function LanAddressField({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (address: string) => void;
+}) {
+  // Mounted once per share surface; deciding at mount is enough because
+  // window.location.hostname can't change without a navigation.
+  const [visible] = useState(() => needsLanOverride());
+  if (!visible) return null;
+  return (
+    <div className="space-y-1">
+      <label htmlFor="presio-lan-address" className="text-xs font-medium text-muted-foreground">
+        This machine&apos;s network address{" "}
+        <span className="font-normal">(so other devices can scan)</span>
+      </label>
+      <input
+        id="presio-lan-address"
+        type="text"
+        inputMode="url"
+        autoComplete="off"
+        spellCheck={false}
+        placeholder="e.g. 192.168.1.20:3001"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+    </div>
+  );
+}

--- a/client/src/components/LanAddressField.tsx
+++ b/client/src/components/LanAddressField.tsx
@@ -85,6 +85,72 @@ export function LanAddressField({
           the address, or whether a firewall is blocking the port.
         </p>
       ) : null}
+      <HowToFindIt />
+    </div>
+  );
+}
+
+// Finding a machine's own LAN address is the one part of this the presenter
+// can't be walked through by the UI alone, so the commands live here rather
+// than in a doc they'd have to go and find. Collapsed by default: it's only
+// needed by whoever hasn't done it before.
+
+function HowToFindIt() {
+  const [open, setOpen] = useState(false);
+  // The port that matters is the one serving this page, not the server's own:
+  // under `npm run dev` the client is on Vite's port.
+  const port = window.location.port;
+  return (
+    <div className="text-xs text-muted-foreground">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="underline underline-offset-2 hover:text-foreground"
+        aria-expanded={open}
+      >
+        How do I find it?
+      </button>
+      {open && (
+        <div className="mt-1 space-y-1">
+          <p>
+            It&apos;s the address of the machine running Presio — the host machine, if it&apos;s in
+            a container — on the network the other devices are on, usually starting{" "}
+            <span className="font-mono">192.168.</span>, <span className="font-mono">10.</span> or{" "}
+            <span className="font-mono">172.</span>
+            {port ? (
+              <>
+                . Add <span className="font-mono">:{port}</span> to whatever you find.
+              </>
+            ) : (
+              "."
+            )}
+          </p>
+          <ul className="space-y-0.5">
+            <li>
+              <span className="font-medium">macOS</span> —{" "}
+              <span className="font-mono">ipconfig getifaddr en0</span> (Wi-Fi;{" "}
+              <span className="font-mono">en1</span> if that&apos;s empty), or System Settings ›
+              Network › the connected adapter.
+            </li>
+            <li>
+              <span className="font-medium">Windows</span> —{" "}
+              <span className="font-mono">ipconfig</span> in PowerShell, then the{" "}
+              <span className="font-mono">IPv4 Address</span> of the adapter you&apos;re connected
+              on.
+            </li>
+            <li>
+              <span className="font-medium">Linux</span> —{" "}
+              <span className="font-mono">hostname -I</span> (the first address), or{" "}
+              <span className="font-mono">ip route get 1.1.1.1</span> and read the{" "}
+              <span className="font-mono">src</span> address.
+            </li>
+          </ul>
+          <p>
+            Phones and laptops must be on the same network — a &ldquo;guest&rdquo; Wi-Fi or client
+            isolation will block the connection even with the right address.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/LanAddressField.tsx
+++ b/client/src/components/LanAddressField.tsx
@@ -6,10 +6,10 @@ import { needsLanOverride, type LanStatus } from "@/lib/joinUrl";
 // It is deliberately not the primary path: the server resolves the address on
 // its own (see lib/joinUrl.ts), so in the ordinary local deployment this
 // collapses to a single line confirming where people will join, and the input
-// only opens if the presenter asks for it. It presents itself when the resolved
-// address failed its reachability check, or when no address could be resolved
-// at all — the bridged-container case, where nothing inside the container can
-// see the host's network.
+// only opens if the presenter asks for it. It presents itself when there's
+// nothing shareable to show — the bridged-container case, where nothing inside
+// the container can see the host's network — or when the resolved address
+// failed its reachability check.
 //
 // Renders nothing when the page was opened on a host other devices can already
 // reach, so hosted deploys never show it.
@@ -19,11 +19,13 @@ export function LanAddressField({
   onChange,
   status,
   origin,
+  shareable,
 }: {
   value: string;
   onChange: (address: string) => void;
   status: LanStatus;
   origin: string;
+  shareable: boolean;
 }) {
   // Deciding at mount is enough because window.location.hostname can't change
   // without a navigation.
@@ -31,10 +33,10 @@ export function LanAddressField({
   const [expanded, setExpanded] = useState(false);
   if (!visible) return null;
 
-  // Don't flash a warning during the round-trip that would resolve it.
+  // Don't flash a prompt during the round-trip that usually answers it.
   if (status === "checking" && !expanded) return null;
 
-  if (status === "ok" && !expanded) {
+  if (shareable && status === "ok" && !expanded) {
     return (
       <p className="text-xs text-muted-foreground">
         Other devices join at <span className="font-mono">{origin}</span>{" "}
@@ -53,7 +55,7 @@ export function LanAddressField({
     <div className="space-y-1">
       <label htmlFor="presio-lan-address" className="text-xs font-medium text-muted-foreground">
         This machine&apos;s network address{" "}
-        <span className="font-normal">(so other devices can scan)</span>
+        <span className="font-normal">(so other devices can join)</span>
       </label>
       <input
         id="presio-lan-address"
@@ -66,19 +68,23 @@ export function LanAddressField({
         onChange={(e) => onChange(e.target.value)}
         className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       />
-      {status === "unreachable" && (
+      {!shareable && value.trim() ? (
+        <p className="text-xs text-amber-600 dark:text-amber-500">
+          Only this device can reach that address. Use the one other devices see this machine at.
+        </p>
+      ) : !shareable ? (
+        <p className="text-xs text-muted-foreground">
+          Presio couldn&apos;t work out this machine&apos;s address, so there&apos;s nothing to
+          share yet — usually because it&apos;s running in a container with its own network. Enter
+          the address here, or set <span className="font-mono">PRESIO_PUBLIC_HOST</span> on the
+          container.
+        </p>
+      ) : status === "unreachable" ? (
         <p className="text-xs text-amber-600 dark:text-amber-500">
           Nothing answered at <span className="font-mono">{origin}</span> from this machine. Check
           the address, or whether a firewall is blocking the port.
         </p>
-      )}
-      {status === "unavailable" && (
-        <p className="text-xs text-muted-foreground">
-          Presio couldn&apos;t work out this machine&apos;s address — it&apos;s running in a
-          container with its own network. Enter the address here, or set{" "}
-          <span className="font-mono">PRESIO_PUBLIC_HOST</span> on the container.
-        </p>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/client/src/components/SessionQRCode.tsx
+++ b/client/src/components/SessionQRCode.tsx
@@ -1,4 +1,5 @@
 import { QRCodeSVG } from "qrcode.react";
+import { joinUrl } from "@/lib/joinUrl";
 
 export function SessionQRCode({
   sessionId,
@@ -7,7 +8,7 @@ export function SessionQRCode({
   sessionId: string;
   size?: number;
 }) {
-  const viewerUrl = `${window.location.origin}/s/${sessionId}?role=viewer`;
+  const viewerUrl = joinUrl(sessionId, "viewer");
   return (
     <div className="text-center space-y-3">
       <p className="text-xs text-muted-foreground">Scan to join as viewer</p>

--- a/client/src/components/SessionQRCode.tsx
+++ b/client/src/components/SessionQRCode.tsx
@@ -4,17 +4,35 @@ import { useJoinUrl } from "@/lib/joinUrl";
 export function SessionQRCode({
   sessionId,
   size = 200,
+  url,
+  shareable,
 }: {
   sessionId: string;
   size?: number;
+  /** Supplied by surfaces that already resolved the join URL, so the QR and the
+   *  links beside it can never disagree. Resolved here otherwise. */
+  url?: string;
+  shareable?: boolean;
 }) {
-  const viewerUrl = useJoinUrl(sessionId, "viewer");
+  const own = useJoinUrl(sessionId, "viewer");
+  const viewerUrl = url ?? own.url;
+  const canShare = shareable ?? own.shareable;
   return (
     <div className="text-center space-y-3">
-      <p className="text-xs text-muted-foreground">Scan to join as viewer</p>
-      <div className="flex justify-center">
-        <QRCodeSVG value={viewerUrl} size={size} className="rounded" />
-      </div>
+      {canShare ? (
+        <>
+          <p className="text-xs text-muted-foreground">Scan to join as viewer</p>
+          <div className="flex justify-center">
+            <QRCodeSVG value={viewerUrl} size={size} className="rounded" />
+          </div>
+        </>
+      ) : (
+        // A QR built from a loopback origin sends the scanning phone back to
+        // itself, so there is nothing worth rendering until an address is known.
+        <p className="text-xs text-muted-foreground">
+          Set this machine&apos;s network address below to show a QR code.
+        </p>
+      )}
       <div className="space-y-0.5">
         <p className="text-xs text-muted-foreground">Session Code</p>
         <p className="text-2xl font-bold tracking-widest font-mono select-all">

--- a/client/src/components/SessionQRCode.tsx
+++ b/client/src/components/SessionQRCode.tsx
@@ -1,5 +1,5 @@
 import { QRCodeSVG } from "qrcode.react";
-import { joinUrl } from "@/lib/joinUrl";
+import { useJoinUrl } from "@/lib/joinUrl";
 
 export function SessionQRCode({
   sessionId,
@@ -8,7 +8,7 @@ export function SessionQRCode({
   sessionId: string;
   size?: number;
 }) {
-  const viewerUrl = joinUrl(sessionId, "viewer");
+  const viewerUrl = useJoinUrl(sessionId, "viewer");
   return (
     <div className="text-center space-y-3">
       <p className="text-xs text-muted-foreground">Scan to join as viewer</p>

--- a/client/src/components/controller/ShareDialog.tsx
+++ b/client/src/components/controller/ShareDialog.tsx
@@ -3,6 +3,7 @@ import { DialogOverlay } from "@/components/ui/dialog-overlay";
 import { SessionQRCode } from "@/components/SessionQRCode";
 import { CopyField } from "@/components/CopyField";
 import { LanAddressField } from "@/components/LanAddressField";
+import type { LanStatus } from "@/lib/joinUrl";
 import { SyncShareOverlay } from "@/components/SyncShareOverlay";
 import { authEnabled } from "@/lib/authMode";
 
@@ -15,6 +16,8 @@ export function ShareDialog({
   controllerUrl,
   lanAddress,
   onLanAddressChange,
+  lanStatus,
+  lanOrigin,
   local,
   loggedIn,
   syncing,
@@ -29,6 +32,8 @@ export function ShareDialog({
   controllerUrl: string;
   lanAddress: string;
   onLanAddressChange: (address: string) => void;
+  lanStatus: LanStatus;
+  lanOrigin: string;
   local: boolean;
   loggedIn: boolean;
   syncing: boolean;
@@ -66,7 +71,12 @@ export function ShareDialog({
             <CopyField label="Viewer link" value={viewerUrl} />
             <CopyField label="Controller link" value={controllerUrl} />
           </div>
-          <LanAddressField value={lanAddress} onChange={onLanAddressChange} />
+          <LanAddressField
+            value={lanAddress}
+            onChange={onLanAddressChange}
+            status={lanStatus}
+            origin={lanOrigin}
+          />
         </>
       )}
       <br />

--- a/client/src/components/controller/ShareDialog.tsx
+++ b/client/src/components/controller/ShareDialog.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { DialogOverlay } from "@/components/ui/dialog-overlay";
 import { SessionQRCode } from "@/components/SessionQRCode";
 import { CopyField } from "@/components/CopyField";
+import { LanAddressField } from "@/components/LanAddressField";
 import { SyncShareOverlay } from "@/components/SyncShareOverlay";
 import { authEnabled } from "@/lib/authMode";
 
@@ -12,6 +13,8 @@ export function ShareDialog({
   id,
   viewerUrl,
   controllerUrl,
+  lanAddress,
+  onLanAddressChange,
   local,
   loggedIn,
   syncing,
@@ -24,6 +27,8 @@ export function ShareDialog({
   id: string;
   viewerUrl: string;
   controllerUrl: string;
+  lanAddress: string;
+  onLanAddressChange: (address: string) => void;
   local: boolean;
   loggedIn: boolean;
   syncing: boolean;
@@ -61,6 +66,7 @@ export function ShareDialog({
             <CopyField label="Viewer link" value={viewerUrl} />
             <CopyField label="Controller link" value={controllerUrl} />
           </div>
+          <LanAddressField value={lanAddress} onChange={onLanAddressChange} />
         </>
       )}
       <br />

--- a/client/src/components/controller/ShareDialog.tsx
+++ b/client/src/components/controller/ShareDialog.tsx
@@ -18,6 +18,7 @@ export function ShareDialog({
   onLanAddressChange,
   lanStatus,
   lanOrigin,
+  lanShareable,
   local,
   loggedIn,
   syncing,
@@ -34,6 +35,7 @@ export function ShareDialog({
   onLanAddressChange: (address: string) => void;
   lanStatus: LanStatus;
   lanOrigin: string;
+  lanShareable: boolean;
   local: boolean;
   loggedIn: boolean;
   syncing: boolean;
@@ -66,16 +68,19 @@ export function ShareDialog({
         </>
       ) : (
         <>
-          <SessionQRCode sessionId={id} />
-          <div className="space-y-2">
-            <CopyField label="Viewer link" value={viewerUrl} />
-            <CopyField label="Controller link" value={controllerUrl} />
-          </div>
+          <SessionQRCode sessionId={id} url={viewerUrl} shareable={lanShareable} />
+          {lanShareable && (
+            <div className="space-y-2">
+              <CopyField label="Viewer link" value={viewerUrl} />
+              <CopyField label="Controller link" value={controllerUrl} />
+            </div>
+          )}
           <LanAddressField
             value={lanAddress}
             onChange={onLanAddressChange}
             status={lanStatus}
             origin={lanOrigin}
+            shareable={lanShareable}
           />
         </>
       )}

--- a/client/src/lib/joinUrl.test.ts
+++ b/client/src/lib/joinUrl.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  composeOrigin,
+  fetchLanOrigin,
+  isLoopbackHostname,
+  lanOrigin,
+  probeOrigin,
+  resolveStatus,
+} from "./joinUrl";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("isLoopbackHostname", () => {
+  it("recognizes every form a local page is served under", () => {
+    for (const host of ["localhost", "127.0.0.1", "127.1.2.3", "::1", "[::1]"]) {
+      expect(isLoopbackHostname(host)).toBe(true);
+    }
+  });
+
+  it("treats LAN and public hosts as already reachable", () => {
+    for (const host of ["192.168.1.20", "presio.xyz", "mybox.local", "10.0.0.5"]) {
+      expect(isLoopbackHostname(host)).toBe(false);
+    }
+  });
+});
+
+describe("lanOrigin", () => {
+  it("inherits the page's scheme for a bare host", () => {
+    expect(lanOrigin("192.168.1.20:3001")).toBe("http://192.168.1.20:3001");
+  });
+
+  it("keeps an explicit scheme and strips trailing slashes", () => {
+    expect(lanOrigin("https://mybox.local:8443//")).toBe("https://mybox.local:8443");
+  });
+
+  it("falls back to the page's own origin when nothing is set", () => {
+    expect(lanOrigin("")).toBe(window.location.origin);
+  });
+});
+
+describe("composeOrigin", () => {
+  const loc = { protocol: "http:", port: "5173" };
+
+  it("borrows the page's port, because that's what the QR has to reach", () => {
+    // The server deliberately reports no port: under `npm run dev` it listens
+    // on 3001 while the page the QR points at is served by Vite on 5173.
+    expect(composeOrigin({ host: "192.168.1.20" }, loc)).toBe("http://192.168.1.20:5173");
+  });
+
+  it("respects a port the deployment configured explicitly", () => {
+    expect(composeOrigin({ host: "192.168.1.20:3001" }, loc)).toBe("http://192.168.1.20:3001");
+  });
+
+  it("omits the port on a default-port page", () => {
+    expect(composeOrigin({ host: "presio.local" }, { protocol: "https:", port: "" })).toBe(
+      "https://presio.local"
+    );
+  });
+
+  it("prefers a fully configured origin over any host", () => {
+    expect(composeOrigin({ host: "192.168.1.20", origin: "https://talks.example.com/" }, loc)).toBe(
+      "https://talks.example.com"
+    );
+  });
+
+  it("returns null when the server had no answer", () => {
+    expect(composeOrigin({ host: null, origin: null, reason: "containerized" }, loc)).toBeNull();
+    expect(composeOrigin(null, loc)).toBeNull();
+  });
+});
+
+describe("fetchLanOrigin", () => {
+  it("treats the 404 from a hosted deployment as 'no answer'", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    expect(await fetchLanOrigin()).toBeNull();
+  });
+
+  it("never throws when the request itself fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    expect(await fetchLanOrigin()).toBeNull();
+  });
+});
+
+describe("probeOrigin", () => {
+  it("reports reachable when the connection is made", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({});
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await probeOrigin("http://192.168.1.20:3001")).toBe(true);
+    // no-cors keeps this independent of CORS and of what the target serves.
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ mode: "no-cors" });
+  });
+
+  it("reports unreachable when it isn't — a firewall drop or a stale address", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("timeout")));
+    expect(await probeOrigin("http://192.168.1.20:3001")).toBe(false);
+  });
+});
+
+describe("resolveStatus", () => {
+  const base = { override: true, typed: "", detected: undefined, candidate: null, probe: null };
+
+  it("short-circuits on a page other devices can already reach", () => {
+    expect(resolveStatus({ ...base, override: false })).toBe("ok");
+  });
+
+  it("waits rather than warning while the lookup is in flight", () => {
+    expect(resolveStatus(base)).toBe("checking");
+  });
+
+  it("asks for an address only once it knows it has none", () => {
+    expect(resolveStatus({ ...base, detected: null })).toBe("unavailable");
+  });
+
+  it("reports a verified address as ok", () => {
+    const candidate = "http://192.168.1.20:3001";
+    expect(
+      resolveStatus({
+        ...base,
+        detected: candidate,
+        candidate,
+        probe: { origin: candidate, reachable: true },
+      })
+    ).toBe("ok");
+  });
+
+  it("warns when the address it has failed verification", () => {
+    const candidate = "http://192.168.1.20:3001";
+    expect(
+      resolveStatus({
+        ...base,
+        detected: candidate,
+        candidate,
+        probe: { origin: candidate, reachable: false },
+      })
+    ).toBe("unreachable");
+  });
+
+  it("ignores a result belonging to a previous candidate", () => {
+    // Typing a new address must not inherit the old one's verdict.
+    expect(
+      resolveStatus({
+        ...base,
+        typed: "10.0.0.9",
+        candidate: "http://10.0.0.9",
+        probe: { origin: "http://192.168.1.20:3001", reachable: false },
+      })
+    ).toBe("checking");
+  });
+});

--- a/client/src/lib/joinUrl.test.ts
+++ b/client/src/lib/joinUrl.test.ts
@@ -4,6 +4,7 @@ import {
   composeOrigin,
   fetchLanOrigin,
   isLoopbackHostname,
+  isShareableOrigin,
   lanOrigin,
   probeOrigin,
   resolveStatus,
@@ -69,6 +70,25 @@ describe("composeOrigin", () => {
   it("returns null when the server had no answer", () => {
     expect(composeOrigin({ host: null, origin: null, reason: "containerized" }, loc)).toBeNull();
     expect(composeOrigin(null, loc)).toBeNull();
+  });
+});
+
+describe("isShareableOrigin", () => {
+  it("rejects loopback origins, which is what the share screen hides on", () => {
+    // Handing these to another device sends it back to itself.
+    for (const origin of ["http://localhost:3001", "http://127.0.0.1:3001", "http://[::1]:3001"]) {
+      expect(isShareableOrigin(origin)).toBe(false);
+    }
+  });
+
+  it("accepts anything another device could reach", () => {
+    expect(isShareableOrigin("http://192.168.1.20:3001")).toBe(true);
+    expect(isShareableOrigin("https://presio.xyz")).toBe(true);
+    expect(isShareableOrigin("http://mybox.local:3001")).toBe(true);
+  });
+
+  it("treats an unparseable origin as not shareable", () => {
+    expect(isShareableOrigin("not a url")).toBe(false);
   });
 });
 

--- a/client/src/lib/joinUrl.ts
+++ b/client/src/lib/joinUrl.ts
@@ -118,6 +118,21 @@ export async function fetchLanOrigin(signal?: AbortSignal): Promise<string | nul
   }
 }
 
+let detection: Promise<string | null> | undefined;
+
+/** The detection request, shared by every surface on the page. A controller can
+ *  have the share dialog, its QR and the viewer overlay mounted at once; the
+ *  answer is a property of the machine, not of the component asking. */
+export function ensureLanOrigin(): Promise<string | null> {
+  detection ??= fetchLanOrigin();
+  return detection;
+}
+
+/** Test seam: drop the shared answer so the next caller asks again. */
+export function resetLanOriginCache() {
+  detection = undefined;
+}
+
 /**
  * Whether something is actually listening on `origin`.
  *
@@ -143,6 +158,22 @@ export async function probeOrigin(origin: string, timeoutMs = PROBE_TIMEOUT_MS):
       signal: AbortSignal.timeout(timeoutMs),
     });
     return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether an origin is worth handing to anyone else.
+ *
+ * A loopback origin is not: every join link and QR built from it sends the
+ * scanning device back to itself. That's the state a local deployment starts
+ * in, and it's the reason the share surfaces hide their links rather than
+ * render a QR code that cannot work.
+ */
+export function isShareableOrigin(origin: string): boolean {
+  try {
+    return !isLoopbackHostname(new URL(origin).hostname);
   } catch {
     return false;
   }
@@ -183,6 +214,8 @@ export function resolveStatus({
 
 interface JoinOrigin {
   origin: string;
+  /** False while the best origin we have is loopback — nothing to share yet. */
+  shareable: boolean;
   status: LanStatus;
   /** Present only when the page is loopback, i.e. when the field is relevant. */
   address: string;
@@ -210,14 +243,12 @@ export function useLanOrigin(): JoinOrigin {
 
   useEffect(() => {
     if (!override) return;
-    const controller = new AbortController();
     let cancelled = false;
-    fetchLanOrigin(controller.signal).then((origin) => {
+    ensureLanOrigin().then((origin) => {
       if (!cancelled) setDetected(origin);
     });
     return () => {
       cancelled = true;
-      controller.abort();
     };
   }, [override]);
 
@@ -243,11 +274,14 @@ export function useLanOrigin(): JoinOrigin {
 
   const status = resolveStatus({ override, typed, detected, candidate, probe });
 
+  const origin = candidate ?? window.location.origin;
+
   return {
     // An unverified candidate is still the best guess available, so it's used
     // while probing and even when the probe failed — the presenter may know
     // something the probe can't see. The status is what drives the warning.
-    origin: candidate ?? window.location.origin,
+    origin,
+    shareable: isShareableOrigin(origin),
     status,
     address,
     setAddress,
@@ -266,7 +300,9 @@ export function useJoinUrls(id: string) {
   };
 }
 
-/** A single join URL, for surfaces that show a QR without the field. */
-export function useJoinUrl(id: string, role: "viewer" | "controller"): string {
-  return `${useLanOrigin().origin}/s/${id}?role=${role}`;
+/** A single join URL, for surfaces that show a QR without the field. Comes with
+ *  the verdict on whether it's worth showing at all. */
+export function useJoinUrl(id: string, role: "viewer" | "controller") {
+  const { origin, shareable } = useLanOrigin();
+  return { url: `${origin}/s/${id}?role=${role}`, shareable };
 }

--- a/client/src/lib/joinUrl.ts
+++ b/client/src/lib/joinUrl.ts
@@ -1,0 +1,73 @@
+// Join URLs (QR codes + copyable controller/viewer links) are built from
+// window.location.origin, which breaks in local deployments: the presenter
+// opens Presio via http://localhost:3001, a phone scans the QR, and resolves
+// localhost to itself. Browsers can't discover their own LAN address (WebRTC
+// ICE probing yields opaque mDNS names on most platforms), so the presenter
+// types this machine's address once — persisted in localStorage — and every
+// share surface rewrites its links/QR to point at it.
+//
+// The override only matters when the current page itself is loopback; hosted
+// deploys (presio.xyz etc.) are always opened by their real host, so they
+// never trigger the UI or rewrite the URLs.
+
+import { useCallback, useState } from "react";
+import { lsGetString, lsSetString, lsRemove, STORAGE_KEYS } from "@/lib/storage";
+
+/** Whether this hostname is only reachable from this same device. */
+export function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    /^127(\.\d+){3}$/.test(hostname) ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
+}
+
+/** Whether the share links need rewriting for other devices to reach them,
+ *  i.e. the presenter is viewing Presio over localhost/loopback. */
+export function needsLanOverride(): boolean {
+  return typeof window !== "undefined" && isLoopbackHostname(window.location.hostname);
+}
+
+const getLanAddress = () => lsGetString(STORAGE_KEYS.lanAddress);
+
+function setLanAddress(value: string) {
+  const trimmed = value.trim();
+  if (trimmed) lsSetString(STORAGE_KEYS.lanAddress, trimmed);
+  else lsRemove(STORAGE_KEYS.lanAddress);
+}
+
+/** The origin share links should point at: the stored LAN address if the
+ *  presenter set one, otherwise the page's own origin. Accepts bare hosts
+ *  ("192.168.1.20", "mybox.local:3001" — protocol inherited from the current
+ *  page) or full URLs; trailing slashes are stripped. */
+export function lanOrigin(address = getLanAddress()): string {
+  if (!address) return window.location.origin;
+  const withProto = /^[a-z][a-z0-9+.-]*:\/\//i.test(address)
+    ? address
+    : `${window.location.protocol}//${address}`;
+  return withProto.replace(/\/+$/, "");
+}
+
+export function joinUrl(id: string, role: "viewer" | "controller"): string {
+  return `${lanOrigin()}/s/${id}?role=${role}`;
+}
+
+/** LAN-address state + the join URLs derived from it, for components that show
+ *  both the field and the rewritten links/QR together. Reads are live per
+ *  render, so surfaces that just display URLs pick up a saved value without
+ *  subscribing. */
+export function useJoinUrls(id: string) {
+  const [address, setAddressState] = useState(() => getLanAddress());
+  const setAddress = useCallback((value: string) => {
+    setAddressState(value);
+    setLanAddress(value);
+  }, []);
+  const origin = lanOrigin(address);
+  return {
+    address,
+    setAddress,
+    viewerUrl: `${origin}/s/${id}?role=viewer`,
+    controllerUrl: `${origin}/s/${id}?role=controller`,
+  };
+}

--- a/client/src/lib/joinUrl.ts
+++ b/client/src/lib/joinUrl.ts
@@ -1,17 +1,37 @@
-// Join URLs (QR codes + copyable controller/viewer links) are built from
-// window.location.origin, which breaks in local deployments: the presenter
-// opens Presio via http://localhost:3001, a phone scans the QR, and resolves
-// localhost to itself. Browsers can't discover their own LAN address (WebRTC
-// ICE probing yields opaque mDNS names on most platforms), so the presenter
-// types this machine's address once — persisted in localStorage — and every
-// share surface rewrites its links/QR to point at it.
+// Join URLs (QR codes + copyable controller/viewer links) used to be built from
+// window.location.origin, which breaks a local deployment: the presenter opens
+// Presio at http://localhost:3001, a phone scans the QR, and resolves localhost
+// to the phone itself.
 //
-// The override only matters when the current page itself is loopback; hosted
-// deploys (presio.xyz etc.) are always opened by their real host, so they
-// never trigger the UI or rewrite the URLs.
+// A browser can't discover its own LAN address — WebRTC ICE candidates are
+// deliberately obfuscated to mDNS names — but the *server* is running on the
+// machine we want the address of, so it can look it up directly
+// (server/lib/lanAddress.ts). Resolution therefore goes, in order:
+//
+//   1. An address the presenter typed here before  — they know best.
+//   2. GET /api/lan-address                        — the usual answer, no input.
+//   3. window.location.origin                      — hosted deploys, unchanged.
+//
+// Whatever wins is then *verified* by fetching it (see probeOrigin), because
+// there are common ways for a plausible address to be unusable: a host firewall
+// dropping the port, or an address stored on a network the presenter has since
+// left. Only when that check fails does the manual field appear — so in the
+// normal case nobody is asked for an IP, and when someone is asked, it's
+// because there is real evidence something is wrong.
+//
+// None of this runs on a hosted deployment: the whole path is gated on the page
+// itself being loopback, which presio.xyz never is.
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { lsGetString, lsSetString, lsRemove, STORAGE_KEYS } from "@/lib/storage";
+
+/** How long to wait for a probe. A firewall DROP sends no RST, so an unguarded
+ *  fetch hangs until the TCP timeout (~75s) — the difference between an instant
+ *  fallback and a share dialog that looks broken. */
+const PROBE_TIMEOUT_MS = 1500;
+
+/** Let typing settle before re-probing a hand-entered address. */
+const EDIT_DEBOUNCE_MS = 600;
 
 /** Whether this hostname is only reachable from this same device. */
 export function isLoopbackHostname(hostname: string): boolean {
@@ -49,25 +69,204 @@ export function lanOrigin(address = getLanAddress()): string {
   return withProto.replace(/\/+$/, "");
 }
 
-export function joinUrl(id: string, role: "viewer" | "controller"): string {
-  return `${lanOrigin()}/s/${id}?role=${role}`;
+// ── Server-side detection ────────────────────────────────────────────────────
+
+export interface LanAddressResponse {
+  host?: string | null;
+  origin?: string | null;
+  source?: string | null;
+  reason?: string | null;
 }
 
-/** LAN-address state + the join URLs derived from it, for components that show
- *  both the field and the rewritten links/QR together. Reads are live per
- *  render, so surfaces that just display URLs pick up a saved value without
- *  subscribing. */
-export function useJoinUrls(id: string) {
-  const [address, setAddressState] = useState(() => getLanAddress());
+interface OriginParts {
+  protocol: string;
+  port: string;
+}
+
+/**
+ * Turn the server's answer into an origin.
+ *
+ * The server reports a host and deliberately not a port, because the port that
+ * matters is the one serving *this page*: under `npm run dev` the client is on
+ * Vite's port while the server is on its own, and the QR has to point at the
+ * former. A host that already carries a port (only possible via an explicitly
+ * configured PRESIO_PUBLIC_HOST) is taken at its word.
+ */
+export function composeOrigin(
+  response: LanAddressResponse | null,
+  { protocol, port }: OriginParts
+): string | null {
+  if (!response) return null;
+  if (response.origin) return response.origin.replace(/\/+$/, "");
+  const host = response.host?.trim();
+  if (!host) return null;
+  const hasPort = /:\d+$/.test(host) || host.endsWith("]");
+  return `${protocol}//${host}${hasPort || !port ? "" : `:${port}`}`;
+}
+
+/** Ask the server for this machine's LAN address. Resolves to null whenever
+ *  there is no usable answer, including the 404 a hosted deployment returns
+ *  because the route isn't registered there at all. */
+export async function fetchLanOrigin(signal?: AbortSignal): Promise<string | null> {
+  try {
+    const res = await fetch("/api/lan-address", { signal, cache: "no-store" });
+    if (!res.ok) return null;
+    const body: LanAddressResponse = await res.json();
+    return composeOrigin(body, window.location);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether something is actually listening on `origin`.
+ *
+ * This runs in the presenter's browser, on the same machine as the server, so a
+ * success does not prove a *phone* can connect — both endpoints are local. What
+ * it reliably catches is the opposite, and that's what it's for: a stale address
+ * from a network the presenter has left, a host firewall dropping the port (a
+ * packet to one's own LAN address still traverses the INPUT chain), or a port
+ * that doesn't match the page's.
+ *
+ * `no-cors` keeps this independent of CORS and of what the target serves — a
+ * resolved promise means the connection was made, a rejection means it wasn't,
+ * and the opaque response body is irrelevant either way. That matters because
+ * the useful target is the page's own port, which under `npm run dev` is Vite
+ * rather than anything that would answer /healthz.
+ */
+export async function probeOrigin(origin: string, timeoutMs = PROBE_TIMEOUT_MS): Promise<boolean> {
+  if (typeof fetch !== "function") return true;
+  try {
+    await fetch(`${origin}/`, {
+      mode: "no-cors",
+      cache: "no-store",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** "checking" — resolving or verifying; "ok" — verified reachable; "unreachable"
+ *  — we have an address but nothing answered on it; "unavailable" — no address
+ *  could be determined (typically a bridged container). */
+export type LanStatus = "checking" | "ok" | "unreachable" | "unavailable";
+
+/**
+ * Status is derived rather than stored: it's a pure function of what we know so
+ * far, and computing it here keeps the effect free of the synchronous setState
+ * that would make every input keystroke cascade an extra render.
+ */
+export function resolveStatus({
+  override,
+  typed,
+  detected,
+  candidate,
+  probe,
+}: {
+  override: boolean;
+  typed: string;
+  detected: string | null | undefined;
+  candidate: string | null;
+  probe: { origin: string; reachable: boolean } | null;
+}): LanStatus {
+  // A page served from a host other devices can reach is reachable by
+  // definition — nothing to look up, nothing to verify.
+  if (!override) return "ok";
+  // Still waiting on the server, with nothing typed to check in the meantime.
+  if (!typed && detected === undefined) return "checking";
+  if (!candidate) return "unavailable";
+  if (probe?.origin !== candidate) return "checking";
+  return probe.reachable ? "ok" : "unreachable";
+}
+
+interface JoinOrigin {
+  origin: string;
+  status: LanStatus;
+  /** Present only when the page is loopback, i.e. when the field is relevant. */
+  address: string;
+  setAddress: (value: string) => void;
+}
+
+/**
+ * Resolve the origin other devices should use, verify it, and expose the manual
+ * override. Hosted deploys short-circuit: the page's own origin is by
+ * definition reachable, so no request is made and the status starts at "ok".
+ */
+export function useLanOrigin(): JoinOrigin {
+  const [override] = useState(() => needsLanOverride());
+  const [address, setAddressState] = useState(() => (override ? getLanAddress() : ""));
+  // undefined while the lookup is in flight, null once it came back empty.
+  const [detected, setDetected] = useState<string | null | undefined>(override ? undefined : null);
+  // Keyed by the origin it describes, so a result never bleeds onto the next
+  // candidate: while they disagree the status is "checking" by construction.
+  const [probe, setProbe] = useState<{ origin: string; reachable: boolean } | null>(null);
+
   const setAddress = useCallback((value: string) => {
     setAddressState(value);
     setLanAddress(value);
   }, []);
-  const origin = lanOrigin(address);
+
+  useEffect(() => {
+    if (!override) return;
+    const controller = new AbortController();
+    let cancelled = false;
+    fetchLanOrigin(controller.signal).then((origin) => {
+      if (!cancelled) setDetected(origin);
+    });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [override]);
+
+  const typed = address.trim();
+  const candidate = typed ? lanOrigin(typed) : (detected ?? null);
+
+  useEffect(() => {
+    if (!override || !candidate) return;
+    let cancelled = false;
+    const timer = setTimeout(
+      () => {
+        probeOrigin(candidate).then((reachable) => {
+          if (!cancelled) setProbe({ origin: candidate, reachable });
+        });
+      },
+      typed ? EDIT_DEBOUNCE_MS : 0
+    );
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [override, typed, candidate]);
+
+  const status = resolveStatus({ override, typed, detected, candidate, probe });
+
   return {
+    // An unverified candidate is still the best guess available, so it's used
+    // while probing and even when the probe failed — the presenter may know
+    // something the probe can't see. The status is what drives the warning.
+    origin: candidate ?? window.location.origin,
+    status,
     address,
     setAddress,
+  };
+}
+
+/** Join URLs plus the LAN-address state behind them, for the share surfaces
+ *  that render both the links and the field. */
+export function useJoinUrls(id: string) {
+  const { origin, ...rest } = useLanOrigin();
+  return {
+    ...rest,
+    origin,
     viewerUrl: `${origin}/s/${id}?role=viewer`,
     controllerUrl: `${origin}/s/${id}?role=controller`,
   };
+}
+
+/** A single join URL, for surfaces that show a QR without the field. */
+export function useJoinUrl(id: string, role: "viewer" | "controller"): string {
+  return `${useLanOrigin().origin}/s/${id}?role=${role}`;
 }

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -38,6 +38,9 @@ export const STORAGE_KEYS = {
   newsletterStatus: "presio_newsletter_status",
   // Test hook: override the prompt delay (ms).
   newsletterDelayOverride: "presio_newsletter_delay_ms",
+  // The presenter machine's LAN address, entered once on the share screen when
+  // Presio is opened over localhost (see lib/joinUrl.ts).
+  lanAddress: "presio_lan_address",
 } as const;
 
 export const timerKey = (id: string) => `presio_timer_${id}`;

--- a/client/src/pages/ControllerView.tsx
+++ b/client/src/pages/ControllerView.tsx
@@ -338,6 +338,7 @@ export function ControllerView({
     setAddress: setLanAddress,
     status: lanStatus,
     origin: lanOrigin,
+    shareable: lanShareable,
     controllerUrl,
     viewerUrl: shareViewerUrl,
   } = useJoinUrls(id);
@@ -574,6 +575,7 @@ export function ControllerView({
           onLanAddressChange={setLanAddress}
           lanStatus={lanStatus}
           lanOrigin={lanOrigin}
+          lanShareable={lanShareable}
           local={local}
           loggedIn={loggedIn}
           syncing={syncing}

--- a/client/src/pages/ControllerView.tsx
+++ b/client/src/pages/ControllerView.tsx
@@ -32,6 +32,7 @@ import { ControllerDashboard, type CardEntry } from "@/components/controller/Con
 import { ControllerStack } from "@/components/controller/ControllerStack";
 import { ShareDialog } from "@/components/controller/ShareDialog";
 import { ConfirmEndDialog } from "@/components/controller/ConfirmEndDialog";
+import { useJoinUrls } from "@/lib/joinUrl";
 import { ConfirmReplaceDialog } from "@/components/controller/ConfirmReplaceDialog";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useSlideTapNav } from "@/hooks/useSlideTapNav";
@@ -328,8 +329,12 @@ export function ControllerView({
     });
   }, []);
 
-  const controllerUrl = `${window.location.origin}/s/${id}?role=controller`;
+  // Navigations this device performs itself (viewer popup) use the page's own
+  // origin — it always works locally. The share dialog's QR/links honor the
+  // presenter-entered LAN address instead (lib/joinUrl.ts), so phones can scan.
   const viewerUrl = `${window.location.origin}/s/${id}?role=viewer`;
+  const { address: lanAddress, setAddress: setLanAddress, controllerUrl, viewerUrl: shareViewerUrl } =
+    useJoinUrls(id);
   const { passphrase = "" } = getSessionAuth(id);
   const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
 
@@ -557,8 +562,10 @@ export function ControllerView({
       {shareDialogOpen && (
         <ShareDialog
           id={id}
-          viewerUrl={viewerUrl}
+          viewerUrl={shareViewerUrl}
           controllerUrl={controllerUrl}
+          lanAddress={lanAddress}
+          onLanAddressChange={setLanAddress}
           local={local}
           loggedIn={loggedIn}
           syncing={syncing}

--- a/client/src/pages/ControllerView.tsx
+++ b/client/src/pages/ControllerView.tsx
@@ -333,8 +333,14 @@ export function ControllerView({
   // origin — it always works locally. The share dialog's QR/links honor the
   // presenter-entered LAN address instead (lib/joinUrl.ts), so phones can scan.
   const viewerUrl = `${window.location.origin}/s/${id}?role=viewer`;
-  const { address: lanAddress, setAddress: setLanAddress, controllerUrl, viewerUrl: shareViewerUrl } =
-    useJoinUrls(id);
+  const {
+    address: lanAddress,
+    setAddress: setLanAddress,
+    status: lanStatus,
+    origin: lanOrigin,
+    controllerUrl,
+    viewerUrl: shareViewerUrl,
+  } = useJoinUrls(id);
   const { passphrase = "" } = getSessionAuth(id);
   const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
 
@@ -566,6 +572,8 @@ export function ControllerView({
           controllerUrl={controllerUrl}
           lanAddress={lanAddress}
           onLanAddressChange={setLanAddress}
+          lanStatus={lanStatus}
+          lanOrigin={lanOrigin}
           local={local}
           loggedIn={loggedIn}
           syncing={syncing}

--- a/client/src/pages/Share.tsx
+++ b/client/src/pages/Share.tsx
@@ -8,7 +8,9 @@ import { useAuth } from "@/lib/useAuth";
 import { authEnabled } from "@/lib/authMode";
 import { useClaim } from "@/lib/useClaim";
 import { LoginDialog } from "@/components/LoginDialog";
+import { LanAddressField } from "@/components/LanAddressField";
 import { SyncShareOverlay } from "@/components/SyncShareOverlay";
+import { useJoinUrls } from "@/lib/joinUrl";
 
 export default function Share() {
   const { id } = useParams<{ id: string }>();
@@ -20,8 +22,11 @@ export default function Share() {
   const [local, setLocal] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
 
-  const controllerUrl = `${window.location.origin}/s/${id}?role=controller`;
-  const viewerUrl = `${window.location.origin}/s/${id}?role=viewer`;
+  // Share URLs honor a presenter-entered LAN address (lib/joinUrl.ts) so QR
+  // codes scanned from other devices resolve when Presio is opened over
+  // localhost in a local deployment.
+  const { address: lanAddress, setAddress: setLanAddress, viewerUrl, controllerUrl } =
+    useJoinUrls(id!);
 
   useEffect(() => {
     let cancelled = false;
@@ -102,6 +107,7 @@ export default function Share() {
             <div className="space-y-3">
               <CopyRow label="Controller link" url={controllerUrl} />
               <CopyRow label="Viewer link" url={viewerUrl} />
+              <LanAddressField value={lanAddress} onChange={setLanAddress} />
             </div>
           )}
 

--- a/client/src/pages/Share.tsx
+++ b/client/src/pages/Share.tsx
@@ -25,8 +25,14 @@ export default function Share() {
   // Share URLs honor a presenter-entered LAN address (lib/joinUrl.ts) so QR
   // codes scanned from other devices resolve when Presio is opened over
   // localhost in a local deployment.
-  const { address: lanAddress, setAddress: setLanAddress, viewerUrl, controllerUrl } =
-    useJoinUrls(id!);
+  const {
+    address: lanAddress,
+    setAddress: setLanAddress,
+    status: lanStatus,
+    origin: lanOrigin,
+    viewerUrl,
+    controllerUrl,
+  } = useJoinUrls(id!);
 
   useEffect(() => {
     let cancelled = false;
@@ -107,7 +113,12 @@ export default function Share() {
             <div className="space-y-3">
               <CopyRow label="Controller link" url={controllerUrl} />
               <CopyRow label="Viewer link" url={viewerUrl} />
-              <LanAddressField value={lanAddress} onChange={setLanAddress} />
+              <LanAddressField
+                value={lanAddress}
+                onChange={setLanAddress}
+                status={lanStatus}
+                origin={lanOrigin}
+              />
             </div>
           )}
 

--- a/client/src/pages/Share.tsx
+++ b/client/src/pages/Share.tsx
@@ -30,6 +30,7 @@ export default function Share() {
     setAddress: setLanAddress,
     status: lanStatus,
     origin: lanOrigin,
+    shareable: lanShareable,
     viewerUrl,
     controllerUrl,
   } = useJoinUrls(id!);
@@ -111,13 +112,20 @@ export default function Share() {
 
           {!local && (
             <div className="space-y-3">
-              <CopyRow label="Controller link" url={controllerUrl} />
-              <CopyRow label="Viewer link" url={viewerUrl} />
+              {/* Loopback links are useless to whoever they're handed to, so
+                  they wait until an address other devices can reach is known. */}
+              {lanShareable && (
+                <>
+                  <CopyRow label="Controller link" url={controllerUrl} />
+                  <CopyRow label="Viewer link" url={viewerUrl} />
+                </>
+              )}
               <LanAddressField
                 value={lanAddress}
                 onChange={setLanAddress}
                 status={lanStatus}
                 origin={lanOrigin}
+                shareable={lanShareable}
               />
             </div>
           )}

--- a/client/src/pages/ViewerView.tsx
+++ b/client/src/pages/ViewerView.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { DialogOverlay } from "@/components/ui/dialog-overlay";
 import { QRCodeSVG } from "qrcode.react";
 import { SessionQRCode } from "@/components/SessionQRCode";
+import { joinUrl } from "@/lib/joinUrl";
 import { ConnectionIndicator } from "@/components/ConnectionIndicator";
 import { MediaOverlay, type MediaState, type MediaTimeSync } from "@/components/MediaOverlay";
 import { AnnotationOverlay } from "@/components/AnnotationOverlay";
@@ -164,7 +165,7 @@ export function ViewerView({
         <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-6 bg-black/95">
           <p className="text-white/70 text-lg select-none">Scan to join this presentation</p>
           <div className="rounded-lg bg-white p-4">
-            <QRCodeSVG value={`${window.location.origin}/s/${id}?role=viewer`} size={260} />
+            <QRCodeSVG value={joinUrl(id, "viewer")} size={260} />
           </div>
           <div className="text-center space-y-1">
             <p className="text-white/50 text-sm select-none">Session code</p>

--- a/client/src/pages/ViewerView.tsx
+++ b/client/src/pages/ViewerView.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { DialogOverlay } from "@/components/ui/dialog-overlay";
 import { QRCodeSVG } from "qrcode.react";
 import { SessionQRCode } from "@/components/SessionQRCode";
-import { joinUrl } from "@/lib/joinUrl";
+import { useJoinUrl } from "@/lib/joinUrl";
 import { ConnectionIndicator } from "@/components/ConnectionIndicator";
 import { MediaOverlay, type MediaState, type MediaTimeSync } from "@/components/MediaOverlay";
 import { AnnotationOverlay } from "@/components/AnnotationOverlay";
@@ -52,6 +52,9 @@ export function ViewerView({
 }) {
   const { totalSlides } = deck;
   const mediaPlacements = deck.mediaBySlide.get(currentSlide) ?? [];
+  // The big "scan to join" overlay is often on a projector driven from the
+  // presenter's own machine over localhost, so it needs the LAN address too.
+  const scanToJoinUrl = useJoinUrl(id, "viewer");
   const navigate = useNavigate();
   const [cursorVisible, setCursorVisible] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -165,7 +168,7 @@ export function ViewerView({
         <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-6 bg-black/95">
           <p className="text-white/70 text-lg select-none">Scan to join this presentation</p>
           <div className="rounded-lg bg-white p-4">
-            <QRCodeSVG value={joinUrl(id, "viewer")} size={260} />
+            <QRCodeSVG value={scanToJoinUrl} size={260} />
           </div>
           <div className="text-center space-y-1">
             <p className="text-white/50 text-sm select-none">Session code</p>

--- a/client/src/pages/ViewerView.tsx
+++ b/client/src/pages/ViewerView.tsx
@@ -54,7 +54,7 @@ export function ViewerView({
   const mediaPlacements = deck.mediaBySlide.get(currentSlide) ?? [];
   // The big "scan to join" overlay is often on a projector driven from the
   // presenter's own machine over localhost, so it needs the LAN address too.
-  const scanToJoinUrl = useJoinUrl(id, "viewer");
+  const scanToJoin = useJoinUrl(id, "viewer");
   const navigate = useNavigate();
   const [cursorVisible, setCursorVisible] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -166,10 +166,16 @@ export function ViewerView({
 
       {showCode && !local && (
         <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-6 bg-black/95">
-          <p className="text-white/70 text-lg select-none">Scan to join this presentation</p>
-          <div className="rounded-lg bg-white p-4">
-            <QRCodeSVG value={scanToJoinUrl} size={260} />
-          </div>
+          <p className="text-white/70 text-lg select-none">
+            {scanToJoin.shareable ? "Scan to join this presentation" : "Join this presentation"}
+          </p>
+          {/* Projected on a big screen, so a QR pointing at loopback would send
+              every phone in the room back to itself. Show the code instead. */}
+          {scanToJoin.shareable && (
+            <div className="rounded-lg bg-white p-4">
+              <QRCodeSVG value={scanToJoin.url} size={260} />
+            </div>
+          )}
           <div className="text-center space-y-1">
             <p className="text-white/50 text-sm select-none">Session code</p>
             <p className="text-white text-4xl font-bold tracking-widest font-mono select-all">

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -316,7 +316,44 @@ database and filesystem storage under `/data` (see `server/local/`) instead of
 Postgres/GoTrue/Storage/Kong. Login and cross-device sync-by-account aren't
 available in this mode (there's no auth provider to back them), but everything
 else works: local presentations, handoff links, and controller/viewer sync
-over Socket.IO. To present to viewers on other devices on the same network,
-have them open `http://<this-machine's-LAN-IP>:3001` instead of `localhost` —
-PDF links are relative, so they resolve correctly either way, and CORS accepts
-any origin in this mode since there's no fixed domain to allow ahead of time.
+over Socket.IO. CORS accepts any origin in this mode since there's no fixed
+domain to allow ahead of time, and PDF links are relative, so they resolve
+correctly whichever address the page was opened at.
+
+### Joining from other devices
+
+Viewers on the same network join by scanning the QR code on the share screen.
+Presio works out this machine's LAN address itself, so on a local install
+there's usually nothing to configure — but it can only do that when it can see
+the host's network, and a container on Docker's default bridge network can't:
+every address it can see belongs to the container. In that case set
+`PRESIO_PUBLIC_HOST` to the address other devices reach this machine on, read
+at run time so it needs no rebuild:
+
+```bash
+docker run -d --name presio -p 3001:3001 \
+  -e PRESIO_MODE=local -e LOCAL_DATA_DIR=/data -e TRUST_PROXY=false \
+  -e PRESIO_PUBLIC_HOST=192.168.1.20:3001 \
+  -v presio-data:/data \
+  ghcr.io/benedict-armstrong/presio-local:1
+```
+
+On Linux, `--network host` works instead and needs no address at all — but not
+on Docker Desktop, where the "host" is a Linux VM rather than your machine.
+Without either, the share screen asks for the address once and remembers it.
+
+To find the address, run this **on the host machine**, not inside the
+container — it's the one on the network your phone or laptop is on, usually
+starting `192.168.`, `10.` or `172.`:
+
+| OS | Command |
+| --- | --- |
+| macOS | `ipconfig getifaddr en0` (Wi-Fi; try `en1` if that's empty), or System Settings › Network |
+| Windows | `ipconfig`, then the `IPv4 Address` of the connected adapter |
+| Linux | `hostname -I` (the first address), or `ip route get 1.1.1.1` and read `src` |
+
+Append the port Presio is served on (`3001` above). Opening
+`http://<that-address>:3001` on the other device directly works too. If it
+doesn't connect, check that both devices are on the same network — guest Wi-Fi
+and client isolation block it regardless of the address — and that the host
+firewall allows the port.

--- a/local.docker-compose.yml
+++ b/local.docker-compose.yml
@@ -20,9 +20,19 @@
 # Working in a checkout instead? `docker compose -f local.docker-compose.yml
 # build` builds from source rather than using the published image.
 #
-# For presenting to viewers on other devices on the same network, open
-# http://<this-machine's-LAN-IP>:3001 on those devices instead of localhost —
-# PDF links are relative, so they resolve correctly either way.
+# Viewers on other devices join by scanning the QR code on the share screen.
+# Presio works out this machine's address for them, but it can only do that when
+# it can see the host's network — and by default this container has its own. Set
+# PRESIO_PUBLIC_HOST so it knows what to point at:
+#
+#   PRESIO_PUBLIC_HOST=$(hostname -I | awk '{print $1}'):3001 \
+#     docker compose -f local.docker-compose.yml up
+#
+# Alternatively add `network_mode: host` (Linux only — on Docker Desktop the
+# "host" is a Linux VM, not your machine), and detection works with no config at
+# all. Without either, the share screen asks for the address once and remembers
+# it. Opening http://<this-machine's-LAN-IP>:3001 directly also works: PDF links
+# are relative, so they resolve either way.
 
 name: presio-local
 
@@ -63,6 +73,11 @@ services:
       LOCAL_DATA_DIR: /data
       # No reverse proxy in front of this container.
       TRUST_PROXY: "false"
+      # The address other devices reach this machine on, e.g. 192.168.1.20:3001.
+      # A container on the default bridge network can't discover it — every
+      # address it can see belongs to the container — so share links fall back
+      # to asking the presenter unless this is set. See the header above.
+      PRESIO_PUBLIC_HOST: ${PRESIO_PUBLIC_HOST:-}
     volumes:
       - presio-local-data:/data
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -14,6 +14,7 @@ import { isLocalMode } from "./local/mode.js";
 import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerNewsletterRoutes } from "./routes/newsletter.js";
 import { registerCheckRoute } from "./routes/check.js";
+import { registerLanAddressRoute } from "./routes/lanAddress.js";
 import { registerAgentDocRoutes } from "./routes/agentDocs.js";
 import { registerMcpRoutes } from "./routes/mcp.js";
 import type { SocketState } from "./socket.js";
@@ -126,6 +127,9 @@ export function createApp({ supabase, io, socketState }: AppDeps): express.Expre
   registerSessionRoutes(app, { supabase, io, socketState });
   registerNewsletterRoutes(app, supabase);
   registerCheckRoute(app);
+  // Local/dev only: lets share surfaces resolve this machine's LAN address
+  // instead of asking the presenter to type it (see lib/lanAddress.ts).
+  registerLanAddressRoute(app, { enabled: devOrLocal });
   registerMcpRoutes(app, supabase);
 
   // Unknown API paths must 404 as JSON — falling through to the SPA catch-all

--- a/server/lanAddress.test.ts
+++ b/server/lanAddress.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import type os from "node:os";
+import type { Server } from "socket.io";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createApp } from "./app.js";
+import { FakeSupabase } from "./test/fakeSupabase.js";
+import { registerLanAddressRoute } from "./routes/lanAddress.js";
+import {
+  addressFromEnv,
+  defaultRouteAddress,
+  isolatedContainer,
+  isReachableFromLan,
+} from "./lib/lanAddress.js";
+
+const fakeIo = { in: () => ({ fetchSockets: async () => [] }) } as unknown as Server;
+
+type Interfaces = NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+
+const iface = (address: string, internal = false) =>
+  [{ address, internal, family: "IPv4", netmask: "", mac: "", cidr: null }] as os.NetworkInterfaceInfo[];
+
+// What a container with its own network namespace sees: itself and nothing else.
+const bridged: Interfaces = { lo: iface("127.0.0.1", true), eth0: iface("172.17.0.2") };
+// What a container sharing the host's stack sees — including the host's own
+// docker bridges, which only exist in the host's namespace.
+const hostNetwork: Interfaces = {
+  lo: iface("127.0.0.1", true),
+  ens160: iface("10.13.0.31"),
+  "br-03f14833d2e1": iface("10.0.1.1"),
+  tailscale0: iface("100.88.111.41"),
+};
+
+describe("addressFromEnv", () => {
+  it("takes a bare host as the authority, port and all", () => {
+    expect(addressFromEnv({ PRESIO_PUBLIC_HOST: " 192.168.1.20:3001/ " })).toEqual({
+      host: "192.168.1.20:3001",
+      origin: null,
+      source: "env",
+    });
+  });
+
+  it("normalizes a full URL to an origin", () => {
+    expect(addressFromEnv({ PRESIO_PUBLIC_HOST: "https://talks.example.com/x" })).toEqual({
+      host: null,
+      origin: "https://talks.example.com",
+      source: "env",
+    });
+  });
+
+  it("falls back to PUBLIC_BASE_URL, which hosted deploys already set", () => {
+    expect(addressFromEnv({ PUBLIC_BASE_URL: "https://presio.xyz" })?.origin).toBe(
+      "https://presio.xyz"
+    );
+  });
+
+  it("prefers the more specific variable when both are set", () => {
+    expect(
+      addressFromEnv({ PRESIO_PUBLIC_HOST: "10.0.0.5", PUBLIC_BASE_URL: "https://presio.xyz" })?.host
+    ).toBe("10.0.0.5");
+  });
+
+  it("ignores an unset or malformed value rather than serving it", () => {
+    expect(addressFromEnv({})).toBeNull();
+    expect(addressFromEnv({ PRESIO_PUBLIC_HOST: "  " })).toBeNull();
+    expect(addressFromEnv({ PRESIO_PUBLIC_HOST: "http://:::" })).toBeNull();
+  });
+});
+
+describe("isolatedContainer", () => {
+  it("declines to answer from a container with its own network namespace", () => {
+    // Every address here is the container's; a phone can reach none of them.
+    expect(isolatedContainer(bridged, true)).toBe(true);
+  });
+
+  it("answers from a container sharing the host's network stack", () => {
+    // Seeing the host's docker bridge proves the namespace is the host's.
+    expect(isolatedContainer(hostNetwork, true)).toBe(false);
+  });
+
+  it("answers when not containerized at all", () => {
+    expect(isolatedContainer(bridged, false)).toBe(false);
+  });
+});
+
+describe("isReachableFromLan", () => {
+  it("accepts an ordinary LAN address", () => {
+    expect(isReachableFromLan("10.13.0.31", hostNetwork)).toBe(true);
+  });
+
+  it("rejects addresses no other device could use", () => {
+    expect(isReachableFromLan(null, hostNetwork)).toBe(false);
+    expect(isReachableFromLan("0.0.0.0", hostNetwork)).toBe(false);
+    expect(isReachableFromLan("127.0.0.1", hostNetwork)).toBe(false);
+    expect(isReachableFromLan("169.254.10.2", hostNetwork)).toBe(false);
+  });
+
+  it("rejects a route that leaves through a docker bridge", () => {
+    // Reachable from containers on this host, useless to a phone.
+    expect(isReachableFromLan("10.0.1.1", hostNetwork)).toBe(false);
+  });
+});
+
+describe("defaultRouteAddress", () => {
+  it("returns a single address, not the list of equals interfaces give", async () => {
+    // Connecting a UDP socket sends no packets — this is a routing-table lookup.
+    // CI runners always have a default route; assert the shape, not the value.
+    const address = await defaultRouteAddress();
+    expect(address === null || /^\d+\.\d+\.\d+\.\d+$/.test(address)).toBe(true);
+  });
+});
+
+describe("GET /api/lan-address", () => {
+  it("is not exposed on a hosted deployment", async () => {
+    // The answer would be meaningless there (the site is reached on its real
+    // domain) and handing anonymous callers the origin's internal addressing is
+    // a disclosure with no upside. NODE_ENV is "test" here, so devOrLocal is
+    // false and the route falls through to the /api JSON 404.
+    const app = createApp({
+      supabase: new FakeSupabase([]) as unknown as SupabaseClient,
+      io: fakeIo,
+    });
+    const res = await request(app).get("/api/lan-address");
+    expect(res.status).toBe(404);
+  });
+
+  it("answers in development and PRESIO_MODE=local", async () => {
+    const app = express();
+    registerLanAddressRoute(app, { enabled: true });
+    const res = await request(app).get("/api/lan-address");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("source");
+  });
+});

--- a/server/lib/lanAddress.ts
+++ b/server/lib/lanAddress.ts
@@ -1,0 +1,165 @@
+import dgram from "node:dgram";
+import fs from "node:fs";
+import os from "node:os";
+
+// Which address should a QR code point at when the presenter opened Presio over
+// http://localhost:3001?
+//
+// The browser can't answer that — it has no way to see its own LAN address, and
+// WebRTC ICE candidates are deliberately obfuscated to mDNS names. But the
+// server is running on the very machine whose address we want, so it can just
+// look. Share surfaces ask this endpoint and rewrite their join links with the
+// answer, which is why a local presenter no longer has to type an IP.
+//
+// Two things make this harder than reading os.networkInterfaces():
+//
+//  1. Machines have several plausible addresses (a Wi-Fi NIC, docker bridges, a
+//     Tailscale interface) and nothing in the interface list ranks them. We
+//     resolve that by asking the routing table instead — see defaultRouteAddress.
+//  2. In a container with its own network namespace (the default for
+//     local.docker-compose.yml) every answer is about the container, not the
+//     host, and would be useless to a phone. We detect that case and decline
+//     rather than hand out a confidently wrong address — see isolatedContainer.
+
+/** RFC 5737 TEST-NET-1: guaranteed never to be routed anywhere real. */
+const PROBE_TARGET = "192.0.2.1";
+
+/** Give up on the routing-table lookup well inside any request timeout. */
+const PROBE_TIMEOUT_MS = 200;
+
+export type LanAddressSource = "env" | "interface";
+
+export interface LanAddress {
+  /** Host to reach this machine on, possibly with a port. The client supplies
+   *  its own scheme, and its own port when this carries none — in `npm run dev`
+   *  the page lives on Vite's port, not the server's. Null when unknown. */
+  host: string | null;
+  /** A complete origin, when the deployment configured one and there is nothing
+   *  for the client to fill in. Takes precedence over `host`. */
+  origin: string | null;
+  source: LanAddressSource | null;
+  /** Why `host`/`origin` are null, for the client to explain to the presenter. */
+  reason?: "containerized" | "no-route";
+}
+
+/** An explicitly configured address always wins: it's the only thing that can
+ *  be right when the server genuinely can't see the address clients use (a
+ *  bridged container, a tunnel, a port-forward). */
+export function addressFromEnv(env: NodeJS.ProcessEnv = process.env): LanAddress | null {
+  const raw = env.PRESIO_PUBLIC_HOST?.trim() || env.PUBLIC_BASE_URL?.trim();
+  if (!raw) return null;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) {
+    try {
+      return { host: null, origin: new URL(raw).origin, source: "env" };
+    } catch {
+      console.error(`Ignoring malformed PRESIO_PUBLIC_HOST/PUBLIC_BASE_URL: ${raw}`);
+      return null;
+    }
+  }
+  return { host: raw.replace(/\/+$/, ""), origin: null, source: "env" };
+}
+
+/**
+ * Whether this process sits in its own network namespace, where every address
+ * it can see belongs to the container rather than to the host a phone would
+ * have to reach.
+ *
+ * The tell is the Docker bridge: dockerd creates docker0 (and a br-* per
+ * user-defined network) in the *host's* namespace, so a container that can see
+ * one is sharing the host's network stack and its addresses are the host's.
+ * A bridged container sees only `lo` and its own `eth0`.
+ */
+export function isolatedContainer(
+  interfaces: NodeJS.Dict<os.NetworkInterfaceInfo[]> = os.networkInterfaces(),
+  containerized = inContainer()
+): boolean {
+  if (!containerized) return false;
+  return !Object.keys(interfaces).some((name) => name === "docker0" || name.startsWith("br-"));
+}
+
+function inContainer(): boolean {
+  if (fs.existsSync("/.dockerenv")) return true;
+  try {
+    return /docker|containerd|kubepods/.test(fs.readFileSync("/proc/1/cgroup", "utf8"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The source address the OS would use to reach the outside world, i.e. the
+ * machine's address on its primary network.
+ *
+ * Connecting a UDP socket sends no packets — it only fixes the socket's local
+ * endpoint — so this is a pure routing-table lookup with no traffic, no
+ * permissions and no dependency on the target existing. It's also the only
+ * portable way to *rank* interfaces: os.networkInterfaces() reports a Wi-Fi
+ * NIC, four docker bridges and a Tailscale address as equals, and picking the
+ * wrong one produces a QR code that silently fails to load.
+ */
+export function defaultRouteAddress(): Promise<string | null> {
+  return new Promise((resolve) => {
+    let socket: dgram.Socket;
+    try {
+      socket = dgram.createSocket("udp4");
+    } catch {
+      resolve(null);
+      return;
+    }
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        socket.close();
+      } catch {
+        // Already closed, or never opened — the answer stands either way.
+      }
+      resolve(value);
+    };
+    // A machine with no route at all never fires the connect callback.
+    const timer = setTimeout(() => finish(null), PROBE_TIMEOUT_MS);
+    timer.unref?.();
+    socket.on("error", () => finish(null));
+    try {
+      socket.connect(53, PROBE_TARGET, () => {
+        try {
+          finish(socket.address().address);
+        } catch {
+          finish(null);
+        }
+      });
+    } catch {
+      finish(null);
+    }
+  });
+}
+
+/** Reject addresses no other device could use, including the case where the
+ *  default route leaves through a docker bridge rather than a real NIC. */
+export function isReachableFromLan(
+  address: string | null,
+  interfaces: NodeJS.Dict<os.NetworkInterfaceInfo[]> = os.networkInterfaces()
+): boolean {
+  if (!address || address === "0.0.0.0") return false;
+  if (address.startsWith("127.") || address.startsWith("169.254.")) return false;
+  return !Object.entries(interfaces).some(
+    ([name, addrs]) =>
+      (name === "docker0" || name.startsWith("br-") || name.startsWith("veth")) &&
+      addrs?.some((a) => a.address === address)
+  );
+}
+
+export async function detectLanAddress(): Promise<LanAddress> {
+  const configured = addressFromEnv();
+  if (configured) return configured;
+  if (isolatedContainer()) {
+    return { host: null, origin: null, source: null, reason: "containerized" };
+  }
+  const address = await defaultRouteAddress();
+  if (!isReachableFromLan(address)) {
+    return { host: null, origin: null, source: null, reason: "no-route" };
+  }
+  return { host: address, origin: null, source: "interface" };
+}

--- a/server/routes/lanAddress.ts
+++ b/server/routes/lanAddress.ts
@@ -1,0 +1,17 @@
+import type express from "express";
+import { detectLanAddress } from "../lib/lanAddress.js";
+
+// GET /api/lan-address — "what should a QR code scanned by a phone point at?"
+//
+// Registered only for development and PRESIO_MODE=local. A hosted deployment is
+// always reached on its real domain, so the answer would be useless there, and
+// publishing the origin's internal addressing to anonymous callers is a needless
+// disclosure. When the route isn't registered the request falls through to the
+// /api JSON 404, which clients treat the same as "no answer" (see
+// client/src/lib/joinUrl.ts).
+export function registerLanAddressRoute(app: express.Express, { enabled }: { enabled: boolean }) {
+  if (!enabled) return;
+  app.get("/api/lan-address", async (_req, res) => {
+    res.json(await detectLanAddress());
+  });
+}


### PR DESCRIPTION
## Summary

Join URLs (QR codes + copyable controller/viewer links) were built from `window.location.origin`, so in a local deployment opened via `http://localhost:3001` the QR code scanned by a phone resolved localhost to the phone itself and never joined.

A browser can't discover its own LAN address — WebRTC ICE candidates are deliberately obfuscated to mDNS names — but the **server is running on the machine whose address we want**, so it can just look it up. Resolution now goes:

1. An address the presenter typed here before — they know best.
2. `GET /api/lan-address` — the usual answer, no input required.
3. `window.location.origin` — hosted deploys, unchanged.

Whatever wins is then **verified** by fetching it, and the manual field only appears when that check fails or no address could be resolved. In the ordinary local deployment nobody is asked for an IP.

When no address is resolved, the fallback origin is loopback — so the share surfaces **hide the join links and the QR entirely** rather than render a QR that sends the scanning phone back to itself. The share page and dialog show the address prompt in their place; the big-screen "scan to join" overlay drops the QR and shows the session code alone. Everything returns the moment an address is known.

## How the server picks an address

`os.networkInterfaces()` isn't enough — it reports a Wi-Fi NIC, four docker bridges and a Tailscale address as equals, and the wrong pick produces a QR code that silently fails. Instead we ask the routing table: connecting a UDP socket to `192.0.2.1` (RFC 5737, never routed) sends no packets but fixes the socket's local endpoint to the address the OS would use to reach the outside world. On a machine with 7 interfaces this returns the one real LAN address.

The endpoint is registered **only** for development and `PRESIO_MODE=local`. On a hosted deployment the answer would be meaningless and publishing internal addressing to anonymous callers is a needless disclosure, so the route isn't mounted at all and requests fall through to the `/api` JSON 404 (covered by a test).

## Containers

In a container with its own network namespace — the default for `local.docker-compose.yml` — every address the server can see belongs to the container, and a phone can reach none of them. That case is detected rather than guessed at: dockerd creates `docker0`/`br-*` in the **host's** namespace, so a container that can see one is sharing the host's stack and its addresses are the host's; a bridged container sees only `lo` and its own `eth0`. Verified both ways:

```
bridge:         ifaces ["eth0"]                              route → 10.0.0.2    (container)
--network host: ifaces ["ens160","br-…","tailscale0", …]     route → 10.13.0.31  (host LAN)
```

When it can't answer, the server says so (`reason: "containerized"`) and the UI explains the fix instead of showing a bare input. `local.docker-compose.yml` now passes `PRESIO_PUBLIC_HOST` through, so a local deploy can be configured once at run time — unlike a `VITE_` build arg, this needs no rebuild per machine.

## Why verify at all

The probe runs in the presenter's browser, on the same machine as the server, so success does **not** prove a phone can connect. It's there for the opposite: it catches a stale address from a network the presenter has left, a host firewall dropping the port (a packet to your own LAN address still traverses the INPUT chain), and a port that doesn't match the page's. `mode: "no-cors"` keeps it independent of CORS and of what the target serves — connection made vs. not is the whole signal — and a hard 1.5s timeout matters because a firewall DROP sends no RST, so an unguarded fetch would hang for ~75s.

The server reports a host and deliberately no port, because the port that matters is the one serving *this page*: under `npm run dev` the client is on Vite's port while the server is on its own.

## Trade-offs considered

- **WebRTC ICE auto-detect**: rejected — mDNS `.local` candidates on most platforms, unreliable for marginal gain.
- **`VITE_LOCAL_HOST` build arg**: rejected — requires a rebuild per machine. `PRESIO_PUBLIC_HOST` is read at run time instead.
- **`network_mode: host` as the default**: rejected — Linux only; on Docker Desktop the "host" is a Linux VM, not the user's machine. Documented as an option.
- **Scope guard**: the whole path is gated on `window.location.hostname` being loopback, so hosted deploys make no request and behave exactly as before.

Closes #62

## Checks

- `client`: `tsc -b` clean, vite production build passes, eslint clean on all touched files (the 2 remaining errors in `ControllerView`/`ViewerView` are pre-existing on main), vitest **53/53** (+23)
- `server`: vitest **41/41** (+14)
- End-to-end against a real local-mode server: `GET /api/lan-address` → `{"host":"10.13.0.31","origin":null,"source":"interface"}`
