### PR TITLE
Let agents update an existing presentation's deck in place

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ These are served live by the Express app (not static files):
 | `/api.md` / `/openapi.json` | API docs |
 | `/robots.txt` / `/sitemap.xml` | Crawl discovery |
 | `/.well-known/mcp.json` / `/mcp` | MCP tools `present_pdf`, `check_pdf` |
-| `POST /api/present` | Upload PDF → local handoff URL |
+| `POST /api/present` | Upload PDF → local handoff URL (update in place with `session_id` + controller token) |
 | `POST /api/check` | Sidecar validity report |
 
 Sources: `server/agent/content/`, `server/routes/agentDocs.ts`, `server/routes/mcp.ts`, `server/lib/presentHandoff.ts`.

--- a/server/agent/content/AGENTS.md
+++ b/server/agent/content/AGENTS.md
@@ -2,7 +2,7 @@
 title: Presio agent brief
 description: What AI agents can do with Presio — capabilities, setup, limits, and examples.
 canonical: BASE/AGENTS.md
-last_updated: 2026-07-15
+last_updated: 2026-08-27
 ---
 
 # Presio agent brief
@@ -10,7 +10,8 @@ last_updated: 2026-07-15
 ## What you can do
 
 1. **Start a local presentation** from a PDF via `POST /api/present` or MCP tool `present_pdf`.
-2. **Validate** Presio notes/media sidecars via `POST /api/check` or MCP tool `check_pdf`.
+2. **Update a presentation you already created** by repeating the present call with its `session_id` + `controller_token` (the `t=` parameter of the returned url) — the deck is replaced in place and the same link keeps working.
+3. **Validate** Presio notes/media sidecars via `POST /api/check` or MCP tool `check_pdf`.
 
 ## Preferred workflow
 
@@ -41,6 +42,10 @@ No API key or configuration required. Optional: send `Authorization: Bearer <tok
 ```bash
 # Start a local presentation — returns a handoff URL to open in a browser
 curl -s -F file=@deck.pdf BASE/api/present
+
+# Replace an existing presentation's deck (same id/link, no extra slot);
+# TOKEN is the t= parameter of the url from the original create response
+curl -s -F file=@deck-v2.pdf -F session_id=ABC123 -F controller_token=$TOKEN BASE/api/present
 
 # Validate notes/media sidecar attachments
 curl -s -F file=@deck.pdf BASE/api/check

--- a/server/agent/content/api.md
+++ b/server/agent/content/api.md
@@ -2,7 +2,7 @@
 title: Presio API
 description: REST reference for starting local PDF presentations and validating sidecars, with curl examples.
 canonical: BASE/api.md
-last_updated: 2026-07-15
+last_updated: 2026-08-27
 ---
 
 # Presio API
@@ -27,6 +27,25 @@ curl -s -F file=@deck.pdf BASE/api/present
 - Unclaimed handoffs expire after **24 hours** (7 days when authenticated).
 - `filename` — display title: the uploaded filename with its `.pdf` extension stripped.
 
+## Updating an existing presentation
+
+To replace an existing presentation's deck instead of creating a new one, repeat `POST /api/present` with two extra multipart fields:
+
+- `session_id` — the presentation's id (`id` from the original create response)
+- `controller_token` — that presentation's controller token, taken from the **`t=` query parameter of the `url` returned when it was created**. The same value may instead be sent as an `x-controller-token` header.
+
+The deck is replaced in place: the response keeps the **same `id` and the same link** (token included), and no additional concurrent-presentation slot is used — you can iterate on slides without minting a fresh URL each pass or hitting the concurrent cap. If the browser has already completed handoff for this session, resending the link pulls the updated deck into it.
+
+```bash
+curl -s -F file=@deck-v2.pdf \
+  -F session_id=ABC123 -F controller_token=TOKEN \
+  BASE/api/present
+```
+
+**200:** `{ id, url, filename, totalSlides, next, updated: true }` — `url` is unchanged from the original response.
+
+Errors: **401** if `session_id` is given without a token, **403** on a wrong token (you cannot overwrite someone else's presentation), **404** when the id is unknown or the session has expired — no new presentation is silently created in any of these cases.
+
 ## POST /api/check
 
 Validate Presio sidecar attachments (notes + media).
@@ -49,3 +68,5 @@ Machine-readable: `BASE/openapi.json`
 ## MCP
 
 `BASE/mcp` — tools `present_pdf`, `check_pdf`
+
+`present_pdf` accepts the same update flow: pass `session_id` + `controller_token` (the `t=` parameter of the url from the original create response) to replace that deck in place and get the same link back.

--- a/server/agent/content/api.md
+++ b/server/agent/content/api.md
@@ -34,7 +34,9 @@ To replace an existing presentation's deck instead of creating a new one, repeat
 - `session_id` — the presentation's id (`id` from the original create response)
 - `controller_token` — that presentation's controller token, taken from the **`t=` query parameter of the `url` returned when it was created**. The same value may instead be sent as an `x-controller-token` header.
 
-The deck is replaced in place: the response keeps the **same `id` and the same link** (token included), and no additional concurrent-presentation slot is used — you can iterate on slides without minting a fresh URL each pass or hitting the concurrent cap. If the browser has already completed handoff for this session, resending the link pulls the updated deck into it.
+The deck is replaced in place: the response keeps the **same `id` and the same `url`** as the original response, and no additional concurrent-presentation slot is used — you can iterate on slides without minting a fresh URL each pass or hitting the concurrent cap. If the browser has already completed handoff for this session, resending the link pulls the updated deck into it — the handoff link revives with the new deck.
+
+Send `session_id` and `controller_token` **at most once each**; a repeated field is rejected with 400 rather than guessed at.
 
 ```bash
 curl -s -F file=@deck-v2.pdf \
@@ -42,9 +44,11 @@ curl -s -F file=@deck-v2.pdf \
   BASE/api/present
 ```
 
-**200:** `{ id, url, filename, totalSlides, next, updated: true }` — `url` is unchanged from the original response.
+**200:** `{ id, url, filename, totalSlides, next, updated: true }` — `url` is unchanged from the original response. For a deck that has been synced for sharing, that `url` is the viewer link (`BASE/s/:id`), which carries no token; live viewers reload the new slides automatically.
 
-Errors: **401** if `session_id` is given without a token, **403** on a wrong token (you cannot overwrite someone else's presentation), **404** when the id is unknown or the session has expired — no new presentation is silently created in any of these cases.
+Errors: **400** if `session_id` or `controller_token` is sent more than once, **401** if `session_id` is given without a token, **403** on a wrong token (you cannot overwrite someone else's presentation), **404** when the id is unknown or the session has expired — no new presentation is silently created in any of these cases.
+
+The upload itself is validated the same way as on create: **400** for a non-PDF or an over-length deck, **413** over 50MB, **422** for bytes that will not parse as a PDF.
 
 ## POST /api/check
 

--- a/server/agent/content/llms-full.txt
+++ b/server/agent/content/llms-full.txt
@@ -40,13 +40,14 @@ curl -s -F file=@deck-v2.pdf \
 
 Response: same shape as create, plus `"updated": true`, with the **same id and same url** — so whoever holds the old link just re-opens it to get the new slides. No additional concurrent-presentation slot is used, which matters when iterating on a deck.
 
-Errors: 401 without a token, 403 on a wrong token, 404 for unknown/expired ids. Never silently creates a new presentation.
+Errors: 400 if `session_id` or `controller_token` is sent more than once, 401 without a token, 403 on a wrong token, 404 for unknown/expired ids. Never silently creates a new presentation.
 
 Notes:
 
 - A wrong token cannot overwrite someone else's presentation, and an unknown or expired id fails with 404 — no new presentation is silently created.
-- If the browser has already completed handoff for this session, re-opening the returned url pulls the updated deck into it.
-- Synced decks updated this way reload live for anyone viewing them.
+- If the browser has already completed handoff for this session, re-opening the returned url pulls the updated deck into it — the link revives with the new deck.
+- Synced decks updated this way reload live for anyone viewing them, over REST and over MCP alike. For a synced deck the returned url is the viewer link (`BASE/s/:id`) and carries no token — keep the token you were given at create time.
+- Send each of `session_id` and `controller_token` exactly once. A duplicated field is a 400, not a silent new presentation.
 
 ## Validate sidecar attachments
 

--- a/server/agent/content/llms-full.txt
+++ b/server/agent/content/llms-full.txt
@@ -28,6 +28,26 @@ The `url` stays valid until a browser claims it (after that the server copy is g
 - Max PDF size: 50MB. Max pages: 3000.
 - Syncing across devices still requires a human login in the UI.
 
+## Update an existing presentation (same link)
+
+Repeating `POST /api/present` with an existing `session_id` and that presentation's `controller_token` replaces the deck in place instead of creating a new presentation. **Where the token comes from:** the original create response's `url` is `BASE/start/:id?t=TOKEN` — `t` is the controller token. Keep it if you may need to update later.
+
+```bash
+curl -s -F file=@deck-v2.pdf \
+  -F session_id=ABC123 -F controller_token=$TOKEN \
+  BASE/api/present
+```
+
+Response: same shape as create, plus `"updated": true`, with the **same id and same url** — so whoever holds the old link just re-opens it to get the new slides. No additional concurrent-presentation slot is used, which matters when iterating on a deck.
+
+Errors: 401 without a token, 403 on a wrong token, 404 for unknown/expired ids. Never silently creates a new presentation.
+
+Notes:
+
+- A wrong token cannot overwrite someone else's presentation, and an unknown or expired id fails with 404 — no new presentation is silently created.
+- If the browser has already completed handoff for this session, re-opening the returned url pulls the updated deck into it.
+- Synced decks updated this way reload live for anyone viewing them.
+
 ## Validate sidecar attachments
 
 ```bash
@@ -42,7 +62,7 @@ Connect an MCP client to `BASE/mcp` (discover via `BASE/.well-known/mcp.json`).
 
 Tools:
 
-- `present_pdf` — same as `POST /api/present` (pass `pdf_base64` + optional `filename`)
+- `present_pdf` — same as `POST /api/present` (pass `pdf_base64` + optional `filename`; add optional `session_id` + `controller_token` to update an existing presentation's deck in place and get the same link back)
 - `check_pdf` — same as `POST /api/check`
 
 If you are a chat assistant with no shell/HTTP tools and Presio is not among your connectors, ask your user to add it once (Claude: Settings → Connectors → Add custom connector → `BASE/mcp`; ChatGPT: Settings → Connectors, developer mode), then retry.

--- a/server/agent/openapi.ts
+++ b/server/agent/openapi.ts
@@ -28,7 +28,7 @@ export function buildOpenApi(base: string) {
                     session_id: {
                       type: "string",
                       description:
-                        "Id of an existing presentation to update in place (from an earlier present response) instead of creating a new one.",
+                        "Id of an existing presentation to update in place (from an earlier present response) instead of creating a new one. Send at most once.",
                     },
                     controller_token: {
                       type: "string",
@@ -54,7 +54,7 @@ export function buildOpenApi(base: string) {
                         type: "string",
                         format: "uri",
                         description:
-                          "Handoff link: valid until a browser claims the deck, or 24h (7 days authenticated) if unclaimed. Fetching without completing handoff does not consume it. Unchanged from the original response when updating.",
+                          "Handoff link: valid until a browser claims the deck, or 24h (7 days authenticated) if unclaimed. Fetching without completing handoff does not consume it. Unchanged from the original response when updating — for a deck that has been synced for sharing this is the viewer link (/s/{id}) instead, which carries no token.",
                       },
                       filename: {
                         type: "string",
@@ -71,9 +71,15 @@ export function buildOpenApi(base: string) {
                 },
               },
             },
+            "400": {
+              description:
+                "Missing or non-PDF file, a deck over the page limit, or session_id/controller_token sent more than once",
+            },
             "401": { description: "session_id given without a controller token" },
             "403": { description: "Wrong controller token for the referenced presentation" },
             "404": { description: "Unknown or expired session_id" },
+            "413": { description: "PDF exceeds the 50MB limit" },
+            "422": { description: "The uploaded bytes could not be parsed as a PDF" },
           },
         },
       },

--- a/server/agent/openapi.ts
+++ b/server/agent/openapi.ts
@@ -12,9 +12,9 @@ export function buildOpenApi(base: string) {
     paths: {
       "/api/present": {
         post: {
-          summary: "Start a local presentation from a PDF",
+          summary: "Start a local presentation from a PDF (or replace an existing one)",
           description:
-            "Stages the PDF and returns a url. Opening the url copies the PDF into the browser (local session), deletes the server copy, and skips the share screen. The url works until a browser claims it; unclaimed handoffs expire after 24 hours (7 days when authenticated).",
+            "Stages the PDF and returns a url. Opening the url copies the PDF into the browser (local session), deletes the server copy, and skips the share screen. The url works until a browser claims it; unclaimed handoffs expire after 24 hours (7 days when authenticated). Pass session_id plus controller_token (the t= parameter of a previously returned url) to instead replace that presentation's deck in place — the response keeps the same id and url, and no additional concurrent-presentation slot is used.",
           operationId: "present",
           requestBody: {
             required: true,
@@ -25,6 +25,16 @@ export function buildOpenApi(base: string) {
                   required: ["file"],
                   properties: {
                     file: { type: "string", format: "binary", description: "PDF file" },
+                    session_id: {
+                      type: "string",
+                      description:
+                        "Id of an existing presentation to update in place (from an earlier present response) instead of creating a new one.",
+                    },
+                    controller_token: {
+                      type: "string",
+                      description:
+                        "Controller token for that presentation — the t= query parameter of the url returned when it was created. Required whenever session_id is given; may be sent as the x-controller-token header instead.",
+                    },
                   },
                 },
               },
@@ -44,7 +54,7 @@ export function buildOpenApi(base: string) {
                         type: "string",
                         format: "uri",
                         description:
-                          "Handoff link: valid until a browser claims the deck, or 24h (7 days authenticated) if unclaimed. Fetching without completing handoff does not consume it.",
+                          "Handoff link: valid until a browser claims the deck, or 24h (7 days authenticated) if unclaimed. Fetching without completing handoff does not consume it. Unchanged from the original response when updating.",
                       },
                       filename: {
                         type: "string",
@@ -52,11 +62,18 @@ export function buildOpenApi(base: string) {
                       },
                       totalSlides: { type: "integer" },
                       next: { type: "string" },
+                      updated: {
+                        type: "boolean",
+                        description: "True when this call replaced an existing presentation instead of creating one.",
+                      },
                     },
                   },
                 },
               },
             },
+            "401": { description: "session_id given without a controller token" },
+            "403": { description: "Wrong controller token for the referenced presentation" },
+            "404": { description: "Unknown or expired session_id" },
           },
         },
       },

--- a/server/app.ts
+++ b/server/app.ts
@@ -126,7 +126,7 @@ export function createApp({ supabase, io, socketState }: AppDeps): express.Expre
   registerSessionRoutes(app, { supabase, io, socketState });
   registerNewsletterRoutes(app, supabase);
   registerCheckRoute(app);
-  registerMcpRoutes(app, supabase);
+  registerMcpRoutes(app, supabase, { io, socketState });
 
   // Unknown API paths must 404 as JSON — falling through to the SPA catch-all
   // returns index.html with a 200, which masks client bugs as parse errors.

--- a/server/lib/presentHandoff.ts
+++ b/server/lib/presentHandoff.ts
@@ -1,7 +1,10 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Server } from "socket.io";
 import { nanoid } from "nanoid";
 import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
 import { isValidTotalSlides, MAX_TOTAL_SLIDES } from "../validation.js";
+import { safeEqual } from "../auth.js";
+import type { SocketState } from "../socket.js";
 import { generatePassphrase, insertSession, ownedExpiry } from "./sessionRows.js";
 
 export const PRESENT_NEXT =
@@ -68,4 +71,122 @@ export async function createPresentHandoff(
 
 export function handoffTokenFrom(req: { get(name: string): string | undefined; query: Record<string, unknown> }): string {
   return req.get("x-controller-token") || (typeof req.query.t === "string" ? req.query.t : "") || "";
+}
+
+export const PRESENT_UPDATED_NEXT =
+  "Deck replaced in place — same link, same presentation. Open url again to hand off the new slides.";
+
+export type PresentUpdateResult =
+  | { ok: true; id: string; url: string; filename: string; totalSlides: number; next: string }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Replace an existing presentation's deck in place, keeping its id, code,
+ * controller token and passphrase, so the same link keeps working and no
+ * additional concurrent-presentation slot is used.
+ *
+ * Two kinds of session land here:
+ *
+ *   - Local handoff sessions (as created by POST /api/present): the new bytes
+ *     are re-staged under the same session so the same /start/:id?t=… link
+ *     claims the replacement into a browser.
+ *   - Synced hosted sessions: the PDF is overwritten at the stored object path
+ *     and viewers in the room get `deck_updated` so they reload live (same
+ *     semantics as POST /api/sessions/:id/pdf).
+ *
+ * Authorization is by controller token only — agent-facing callers never hold
+ * a Supabase session, so owner-based authorization doesn't apply here.
+ */
+export async function updatePresentDeck(
+  supabase: SupabaseClient,
+  opts: {
+    sessionId: string;
+    token: string;
+    buffer: Buffer;
+    originalName?: string;
+    baseUrl: string;
+    io?: Server;
+    socketState?: SocketState;
+  }
+): Promise<PresentUpdateResult> {
+  const { data: row, error } = await supabase
+    .from("sessions")
+    .select("id, local, pdf_path, filename, current_slide, controller_token")
+    .eq("id", opts.sessionId)
+    .neq("status", "expired")
+    .single();
+  if (error || !row) {
+    return { ok: false, status: 404, error: "Presentation not found or expired" };
+  }
+  if (!safeEqual(opts.token, row.controller_token)) {
+    return { ok: false, status: 403, error: "Not authorized" };
+  }
+
+  let totalSlides: number;
+  try {
+    const doc = await getDocument({ data: new Uint8Array(opts.buffer) }).promise;
+    totalSlides = doc.numPages;
+    doc.destroy();
+  } catch {
+    return { ok: false, status: 422, error: "Could not parse PDF" };
+  }
+  if (!isValidTotalSlides(totalSlides)) {
+    return { ok: false, status: 400, error: `PDF exceeds the ${MAX_TOTAL_SLIDES}-page limit` };
+  }
+
+  // An empty name means "keep the current title" rather than resetting it.
+  const rawName = (opts.originalName ?? "").trim().replace(/\.pdf$/i, "");
+  const filename = rawName || row.filename || "presentation";
+  // Keep the presenter near where they were; drawings keyed by slide number
+  // beyond the new count become stale just as with the notes replace path.
+  const clampedSlide = Math.min(Math.max(row.current_slide ?? 1, 1), totalSlides);
+
+  if (row.local) {
+    // Handoff may already be complete (the browser cleared the server copy),
+    // in which case restage under a fresh path — the link revives with the new deck.
+    const pdfPath = row.pdf_path || `handoff/${nanoid(32)}.pdf`;
+    const { error: uploadError } = await supabase.storage
+      .from("presentations")
+      .upload(pdfPath, opts.buffer, { contentType: "application/pdf", upsert: true });
+    if (uploadError) {
+      console.error("Failed to stage updated PDF:", uploadError);
+      return { ok: false, status: 500, error: "Failed to upload PDF" };
+    }
+    const { error: updateError } = await supabase
+      .from("sessions")
+      .update({ pdf_path: pdfPath, total_slides: totalSlides, current_slide: clampedSlide, filename })
+      .eq("id", row.id);
+    if (updateError) {
+      return { ok: false, status: 500, error: "Failed to update presentation" };
+    }
+    const url = `${opts.baseUrl}/start/${row.id}?t=${row.controller_token}`;
+    return { ok: true, id: row.id, url, filename, totalSlides, next: PRESENT_UPDATED_NEXT };
+  }
+
+  if (!row.pdf_path) {
+    return { ok: false, status: 400, error: "This presentation's PDF is not hosted on the server" };
+  }
+  const { error: uploadError } = await supabase.storage
+    .from("presentations")
+    .upload(row.pdf_path, opts.buffer, { contentType: "application/pdf", upsert: true });
+  if (uploadError) {
+    return { ok: false, status: 500, error: "Failed to save PDF" };
+  }
+  const { error: updateError } = await supabase
+    .from("sessions")
+    .update({
+      total_slides: totalSlides,
+      current_slide: clampedSlide,
+      ...(rawName ? { filename } : {}),
+    })
+    .eq("id", row.id);
+  if (updateError) {
+    return { ok: false, status: 500, error: "Failed to update presentation" };
+  }
+
+  // Everyone in the room reloads the new bytes live, as with any other replacement.
+  opts.socketState?.annotations.delete(String(row.id));
+  opts.io?.to(row.id).emit("deck_updated", { filename, totalSlides });
+
+  return { ok: true, id: row.id, url: `${opts.baseUrl}/s/${row.id}`, filename, totalSlides, next: PRESENT_UPDATED_NEXT };
 }

--- a/server/lib/presentHandoff.ts
+++ b/server/lib/presentHandoff.ts
@@ -76,6 +76,11 @@ export function handoffTokenFrom(req: { get(name: string): string | undefined; q
 export const PRESENT_UPDATED_NEXT =
   "Deck replaced in place — same link, same presentation. Open url again to hand off the new slides.";
 
+// Synced decks have no handoff step: viewers reload the new bytes themselves,
+// and `url` is the shared viewer link, not a `?t=` handoff link.
+export const PRESENT_SYNCED_UPDATED_NEXT =
+  "Deck replaced in place — same link, same presentation. Anyone viewing it reloads the new slides automatically.";
+
 export type PresentUpdateResult =
   | { ok: true; id: string; url: string; filename: string; totalSlides: number; next: string }
   | { ok: false; status: number; error: string };
@@ -114,6 +119,10 @@ export async function updatePresentDeck(
     .select("id, local, pdf_path, filename, current_slide, controller_token")
     .eq("id", opts.sessionId)
     .neq("status", "expired")
+    // `status` is only reconciled by the hourly sweeper in index.ts, so a row
+    // past its expiry can still read as active. Check the timestamp too, or an
+    // update revives a presentation the API documents as gone.
+    .gt("expires_at", new Date().toISOString())
     .single();
   if (error || !row) {
     return { ok: false, status: 404, error: "Presentation not found or expired" };
@@ -188,5 +197,12 @@ export async function updatePresentDeck(
   opts.socketState?.annotations.delete(String(row.id));
   opts.io?.to(row.id).emit("deck_updated", { filename, totalSlides });
 
-  return { ok: true, id: row.id, url: `${opts.baseUrl}/s/${row.id}`, filename, totalSlides, next: PRESENT_UPDATED_NEXT };
+  return {
+    ok: true,
+    id: row.id,
+    url: `${opts.baseUrl}/s/${row.id}`,
+    filename,
+    totalSlides,
+    next: PRESENT_SYNCED_UPDATED_NEXT,
+  };
 }

--- a/server/mcp.test.ts
+++ b/server/mcp.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import request from "supertest";
+import type { Server } from "socket.io";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type express from "express";
+import { createApp } from "./app.js";
+import { FakeSupabase, type SessionRow } from "./test/fakeSupabase.js";
+
+const fakeIo = { in: () => ({ fetchSockets: async () => [] }) } as unknown as Server;
+
+function appWith(fake: FakeSupabase) {
+  return createApp({ supabase: fake as unknown as SupabaseClient, io: fakeIo });
+}
+
+const future = () => new Date(Date.now() + 86_400_000).toISOString();
+
+// A real PDF — present parses the upload with pdf.js to count pages.
+const realPdf = fs.readFileSync("../example/example.pdf");
+
+// The MCP transport answers with an SSE stream; pull the single data payload out.
+async function callPresent(app: express.Express, args: Record<string, unknown>) {
+  const res = await request(app)
+    .post("/mcp")
+    .set("Accept", "application/json, text/event-stream")
+    .send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "present_pdf", arguments: args },
+    });
+  expect(res.status).toBe(200);
+  return res;
+}
+
+function toolResult(res: request.Response): { isError?: boolean; text?: string } {
+  // Response may arrive as application/json or as a one-event SSE stream.
+  if (res.body && Object.keys(res.body).length) {
+    return pick(res.body?.result);
+  }
+  const sse = String(res.text || "");
+  const match = sse.match(/^data: (.*)$/m);
+  expect(match, "expected an SSE data event").toBeTruthy();
+  const body = JSON.parse(match![1]);
+  if (body.error) throw new Error(body.error.message);
+  return pick(body.result);
+}
+
+function pick(result: { isError?: boolean; content?: { type: string; text: string }[] } | undefined) {
+  const first = result?.content?.[0];
+  return { isError: result?.isError, text: first && "text" in first ? first.text : undefined };
+}
+
+// A local handoff session, as minted by POST /api/present.
+const handoffRow = (over: Partial<SessionRow> = {}): SessionRow => ({
+  id: "HND001",
+  pdf_path: "handoff/old.pdf",
+  filename: "Old deck",
+  total_slides: 5,
+  current_slide: 2,
+  local: true,
+  controller_token: "handoff-token",
+  passphrase: "PASS1234",
+  user_id: null,
+  expires_at: future(),
+  ...over,
+});
+
+describe("MCP present_pdf (update in place)", () => {
+  it("replaces an existing deck and returns the same link when session_id + controller_token are given", async () => {
+    const fake = new FakeSupabase([handoffRow()]);
+    const app = appWith(fake);
+    const res = await callPresent(app, {
+      pdf_base64: realPdf.toString("base64"),
+      filename: "v2.pdf",
+      session_id: "HND001",
+      controller_token: "handoff-token",
+    });
+
+    const result = toolResult(res);
+    expect(result.isError).toBeFalsy();
+    const payload = JSON.parse(result.text!);
+    expect(payload.id).toBe("HND001");
+    expect(payload.url).toMatch(/\/start\/HND001\?t=handoff-token$/);
+    expect(payload.updated).toBe(true);
+
+    // Same row, same token, new bytes — no extra slot consumed.
+    expect(fake.rows).toHaveLength(1);
+    expect(fake.rows[0].controller_token).toBe("handoff-token");
+    expect(fake.rows[0].filename).toBe("v2");
+    expect(fake.rows[0].total_slides).toBeGreaterThan(0);
+  });
+
+  it("errors without controller_token and leaves the presentation untouched", async () => {
+    const fake = new FakeSupabase([handoffRow()]);
+    const app = appWith(fake);
+    const res = await callPresent(app, {
+      pdf_base64: realPdf.toString("base64"),
+      session_id: "HND001",
+    });
+
+    const result = toolResult(res);
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/controller_token is required/i);
+    expect(fake.rows[0].filename).toBe("Old deck");
+    expect(fake.uploaded.size).toBe(0);
+  });
+
+  it("errors on a wrong token instead of overwriting", async () => {
+    const fake = new FakeSupabase([handoffRow()]);
+    const app = appWith(fake);
+    const res = await callPresent(app, {
+      pdf_base64: realPdf.toString("base64"),
+      session_id: "HND001",
+      controller_token: "wrong",
+    });
+
+    const result = toolResult(res);
+    expect(result.isError).toBe(true);
+    expect(result.text).toBe("Not authorized");
+    expect(fake.uploaded.size).toBe(0);
+  });
+
+  it("errors on an unknown session rather than creating one", async () => {
+    const fake = new FakeSupabase([]);
+    const app = appWith(fake);
+    const res = await callPresent(app, {
+      pdf_base64: realPdf.toString("base64"),
+      session_id: "NOPE01",
+      controller_token: "whatever",
+    });
+
+    const result = toolResult(res);
+    expect(result.isError).toBe(true);
+    expect(result.text).toMatch(/not found or expired/i);
+    expect(fake.rows).toHaveLength(0);
+  });
+});

--- a/server/mcp.test.ts
+++ b/server/mcp.test.ts
@@ -7,11 +7,34 @@ import type express from "express";
 import { createApp } from "./app.js";
 import { FakeSupabase, type SessionRow } from "./test/fakeSupabase.js";
 
-const fakeIo = { in: () => ({ fetchSockets: async () => [] }) } as unknown as Server;
+// Emissions are recorded so tests can assert that an MCP deck replacement
+// reaches live viewers, exactly as the REST one does.
+const fakeEmissions: { room: string; event: string; payload: unknown }[] = [];
+const fakeIo = {
+  in: () => ({ fetchSockets: async () => [] }),
+  to: (room: string) => ({
+    emit: (event: string, payload?: unknown) => fakeEmissions.push({ room, event, payload }),
+  }),
+} as unknown as Server;
 
 function appWith(fake: FakeSupabase) {
   return createApp({ supabase: fake as unknown as SupabaseClient, io: fakeIo });
 }
+
+// A synced hosted session — the only kind that has live viewers to notify.
+const syncedRow = (over: Partial<SessionRow> = {}): SessionRow => ({
+  id: "ABC123",
+  pdf_path: "ABC123.pdf",
+  filename: "Talk",
+  total_slides: 12,
+  current_slide: 3,
+  local: false,
+  controller_token: "secret-token",
+  passphrase: "PASS1234",
+  user_id: "user-1",
+  expires_at: future(),
+  ...over,
+});
 
 const future = () => new Date(Date.now() + 86_400_000).toISOString();
 
@@ -89,6 +112,42 @@ describe("MCP present_pdf (update in place)", () => {
     expect(fake.rows[0].controller_token).toBe("handoff-token");
     expect(fake.rows[0].filename).toBe("v2");
     expect(fake.rows[0].total_slides).toBeGreaterThan(0);
+  });
+
+  it("broadcasts deck_updated for a synced deck, like the REST path", async () => {
+    const fake = new FakeSupabase([syncedRow()]);
+    fakeEmissions.length = 0;
+    const app = appWith(fake);
+    const res = await callPresent(app, {
+      pdf_base64: realPdf.toString("base64"),
+      filename: "talk-v2.pdf",
+      session_id: "ABC123",
+      controller_token: "secret-token",
+    });
+
+    const result = toolResult(res);
+    expect(result.isError).toBeFalsy();
+    // registerMcpRoutes has to be handed io/socketState, or updatePresentDeck
+    // skips the emit and every viewer stays on the old slides.
+    expect(fakeEmissions).toContainEqual(
+      expect.objectContaining({ room: "ABC123", event: "deck_updated" })
+    );
+  });
+
+  it("returns the documented payload shape without the internal ok flag", async () => {
+    const fake = new FakeSupabase([handoffRow()]);
+    const app = appWith(fake);
+    const res = await callPresent(app, {
+      pdf_base64: realPdf.toString("base64"),
+      filename: "v2.pdf",
+      session_id: "HND001",
+      controller_token: "handoff-token",
+    });
+
+    const payload = JSON.parse(toolResult(res).text!);
+    expect(Object.keys(payload).sort()).toEqual(
+      ["filename", "id", "next", "totalSlides", "updated", "url"].sort()
+    );
   });
 
   it("errors without controller_token and leaves the presentation untouched", async () => {

--- a/server/rest.test.ts
+++ b/server/rest.test.ts
@@ -345,6 +345,69 @@ describe("POST /api/present (update in place)", () => {
     expect(res.status).toBe(404);
   });
 
+  it("returns exactly the documented response shape", async () => {
+    const fake = new FakeSupabase([handoffRow({})]);
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "HND001")
+      .field("controller_token", "handoff-token")
+      .attach("file", realPdf, { filename: "v2.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(200);
+    // `ok` is an internal discriminant on PresentUpdateResult — it must not
+    // leak into the response, which create whitelists and the docs pin down.
+    expect(Object.keys(res.body).sort()).toEqual(
+      ["filename", "id", "next", "totalSlides", "updated", "url"].sort()
+    );
+  });
+
+  it("400s when session_id is sent twice instead of silently creating", async () => {
+    const fake = new FakeSupabase([handoffRow({})]);
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "HND001")
+      .field("session_id", "HND001")
+      .field("controller_token", "handoff-token")
+      .attach("file", realPdf, { filename: "v2.pdf", contentType: "application/pdf" });
+
+    // Multer hands a repeated field back as an array; reading that as "absent"
+    // used to fall through to create — a new id, a new token and a burnt slot.
+    expect(res.status).toBe(400);
+    expect(fake.rows).toHaveLength(1);
+    expect(fake.rows[0].filename).toBe("Old deck");
+  });
+
+  it("400s when controller_token is sent twice", async () => {
+    const fake = new FakeSupabase([handoffRow({})]);
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "HND001")
+      .field("controller_token", "handoff-token")
+      .field("controller_token", "handoff-token")
+      .attach("file", realPdf, { filename: "v2.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(400);
+    expect(fake.rows).toHaveLength(1);
+  });
+
+  it("404s on a session past expires_at that the sweeper has not marked yet", async () => {
+    const past = new Date(Date.now() - 86_400_000).toISOString();
+    const fake = new FakeSupabase([handoffRow({ expires_at: past })]);
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "HND001")
+      .field("controller_token", "handoff-token")
+      .attach("file", realPdf, { filename: "v2.pdf", contentType: "application/pdf" });
+
+    // status is only reconciled hourly, so an expired row can still read active.
+    expect(res.status).toBe(404);
+    expect(fake.uploaded.size).toBe(0);
+  });
+
   it("updates a synced hosted deck and broadcasts deck_updated", async () => {
     const fake = new FakeSupabase([
       baseRow({ current_slide: 50 }), // clamp into range
@@ -366,5 +429,8 @@ describe("POST /api/present (update in place)", () => {
     expect(fakeEmissions).toContainEqual(
       expect.objectContaining({ room: "ABC123", event: "deck_updated" })
     );
+    // A synced deck has no handoff step, so it must not be told to open a
+    // handoff link — viewers already reloaded.
+    expect(res.body.next).not.toMatch(/hand off/i);
   });
 });

--- a/server/rest.test.ts
+++ b/server/rest.test.ts
@@ -8,8 +8,16 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { createApp } from "./app.js";
 import { FakeSupabase, type SessionRow } from "./test/fakeSupabase.js";
 
-// A no-op io stand-in: the DELETE route only calls io.in(id).fetchSockets().
-const fakeIo = { in: () => ({ fetchSockets: async () => [] }) } as unknown as Server;
+// A no-op io stand-in: the DELETE route only calls io.in(id).fetchSockets(),
+// and the deck-update path broadcasts via io.to(id).emit(). Emissions are
+// recorded so tests can assert viewers were told to reload.
+const fakeEmissions: { room: string; event: string; payload: unknown }[] = [];
+const fakeIo = {
+  in: () => ({ fetchSockets: async () => [] }),
+  to: (room: string) => ({
+    emit: (event: string, payload?: unknown) => fakeEmissions.push({ room, event, payload }),
+  }),
+} as unknown as Server;
 
 function appWith(fake: FakeSupabase) {
   return createApp({ supabase: fake as unknown as SupabaseClient, io: fakeIo });
@@ -207,5 +215,156 @@ describe("POST /api/sessions/external (validation)", () => {
     expect(res.body.id).toMatch(/^[A-Z0-9]{6}$/);
     expect(res.body).toHaveProperty("controllerToken");
     expect(fake.rows).toHaveLength(1);
+  });
+});
+
+// A local handoff session, as minted by POST /api/present.
+const handoffRow = (over: Partial<SessionRow> = {}): SessionRow => ({
+  id: "HND001",
+  pdf_path: "handoff/old.pdf",
+  filename: "Old deck",
+  total_slides: 5,
+  current_slide: 2,
+  local: true,
+  controller_token: "handoff-token",
+  passphrase: "PASS1234",
+  user_id: null,
+  expires_at: future(),
+  ...over,
+});
+
+describe("POST /api/present (create)", () => {
+  it("keeps today's create behaviour when no session_id is given", async () => {
+    const fake = new FakeSupabase([]);
+    const app = appWith(fake);
+    const res = await request(app).post("/api/present").attach("file", realPdf, {
+      filename: "deck.pdf",
+      contentType: "application/pdf",
+    });
+
+    expect(res.status).toBe(200);
+    expect(Object.keys(res.body).sort()).toEqual(["filename", "id", "next", "totalSlides", "url"].sort());
+    expect(res.body.url).toMatch(/^http:\/\/.+\/start\/[A-Z0-9]{6}\?t=/);
+    expect(fake.rows).toHaveLength(1);
+    expect(fake.rows[0].local).toBe(true);
+  });
+});
+
+describe("POST /api/present (update in place)", () => {
+  it("replaces a local handoff deck and returns the same link and token", async () => {
+    const fake = new FakeSupabase([handoffRow({})]);
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "HND001")
+      .field("controller_token", "handoff-token")
+      .attach("file", realPdf, { filename: "new-deck.PDF", contentType: "application/pdf" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updated).toBe(true);
+    // Same presentation → same id and same link/token as the original create.
+    expect(res.body.id).toBe("HND001");
+    expect(res.body.url).toMatch(/^http:\/\/[^/]+\/start\/HND001\?t=handoff-token$/);
+    expect(res.body.totalSlides).toBeGreaterThan(0);
+
+    // The row is reused, not duplicated — no extra concurrent slot.
+    expect(fake.rows).toHaveLength(1);
+    expect(fake.rows[0].local).toBe(true);
+    expect(fake.rows[0].controller_token).toBe("handoff-token");
+    expect(fake.rows[0].filename).toBe("new-deck");
+    expect(fake.rows[0].pdf_path).toBe("handoff/old.pdf");
+    expect(fake.uploaded.get("handoff/old.pdf")?.length).toBe(realPdf.length);
+  });
+
+  it("accepts the token via the x-controller-token header too", async () => {
+    const fake = new FakeSupabase([handoffRow({ pdf_path: "" })]); // handoff already completed
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .set("x-controller-token", "handoff-token")
+      .field("session_id", "HND001")
+      .attach("file", realPdf, { filename: "v2.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(200);
+    // Server copy was cleared by a prior handoff; the update restages it so
+    // the link revives.
+    expect(fake.rows[0].pdf_path).not.toBe("");
+    expect(fake.uploaded.get(fake.rows[0].pdf_path!)).toBeDefined();
+  });
+
+  it("403s on a wrong token and leaves the row untouched", async () => {
+    const fake = new FakeSupabase([handoffRow({})]);
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "HND001")
+      .field("controller_token", "wrong-token")
+      .attach("file", realPdf, { filename: "evil.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(403);
+    expect(fake.rows).toHaveLength(1);
+    expect(fake.rows[0].filename).toBe("Old deck");
+    expect(fake.uploaded.size).toBe(0);
+  });
+
+  it("401s when session_id is given without any controller token", async () => {
+    const fake = new FakeSupabase([handoffRow({})]);
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "HND001")
+      .attach("file", realPdf, { filename: "deck.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(401);
+    expect(fake.rows).toHaveLength(1);
+  });
+
+  it("404s on an unknown session instead of creating a new one", async () => {
+    const fake = new FakeSupabase([]);
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "NOPE01")
+      .field("controller_token", "whatever")
+      .attach("file", realPdf, { filename: "deck.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(404);
+    expect(JSON.parse(JSON.stringify(res.body)).error).toMatch(/not found or expired/i);
+    expect(fake.rows).toHaveLength(0); // no silent create
+  });
+
+  it("404s on an expired session", async () => {
+    const fake = new FakeSupabase([handoffRow({ status: "expired" })]);
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "HND001")
+      .field("controller_token", "handoff-token")
+      .attach("file", realPdf, { filename: "deck.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("updates a synced hosted deck and broadcasts deck_updated", async () => {
+    const fake = new FakeSupabase([
+      baseRow({ current_slide: 50 }), // clamp into range
+    ]);
+    fakeEmissions.length = 0;
+    const app = appWith(fake);
+    const res = await request(app)
+      .post("/api/present")
+      .field("session_id", "ABC123")
+      .field("controller_token", "secret-token")
+      .attach("file", realPdf, { filename: "talk-v2.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe("ABC123");
+    expect(res.body.url).toMatch(/^http:\/\/[^/]+\/s\/ABC123$/);
+    expect(fake.rows).toHaveLength(1); // still one slot in use
+    expect(fake.rows[0].total_slides).toBeGreaterThan(0);
+    expect(fake.rows[0].current_slide).toBeGreaterThan(0);
+    expect(fakeEmissions).toContainEqual(
+      expect.objectContaining({ room: "ABC123", event: "deck_updated" })
+    );
   });
 });

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -1,4 +1,5 @@
 import type express from "express";
+import type { Server } from "socket.io";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -7,8 +8,18 @@ import { baseUrl } from "../lib/baseUrl.js";
 import { createPresentHandoff, updatePresentDeck } from "../lib/presentHandoff.js";
 import { buildCheckReport } from "./check.js";
 import { resolveOptionalUserId } from "../auth.js";
+import type { SocketState } from "../socket.js";
 
-function createPresioMcp(supabase: SupabaseClient, origin: string, req: express.Request) {
+/** Live-broadcast deps, so an MCP deck replacement reaches viewers exactly as
+ *  the REST one does. Without them `updatePresentDeck` silently skips the
+ *  `deck_updated` emit and leaves everyone watching a synced deck on the old
+ *  slides with stale drawings. */
+export interface McpDeps {
+  io?: Server;
+  socketState?: SocketState;
+}
+
+function createPresioMcp(supabase: SupabaseClient, origin: string, req: express.Request, deps: McpDeps) {
   const server = new McpServer({
     name: "presio",
     version: "1.0.0",
@@ -22,7 +33,9 @@ function createPresioMcp(supabase: SupabaseClient, origin: string, req: express.
         "Upload a PDF to start a local Presio presentation. Returns a url — open it in a browser to finish handoff (skips share). To replace an existing presentation's deck instead of creating one, pass its session_id plus controller_token (the t= parameter of the url from the original create call) and the same link keeps working. Same as POST /api/present.",
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        // Creating is additive, but the session_id path overwrites an existing
+        // deck in place and the old slides are not recoverable.
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: false,
       },
@@ -56,11 +69,22 @@ function createPresioMcp(supabase: SupabaseClient, origin: string, req: express.
           buffer,
           originalName: filename || "",
           baseUrl: origin,
+          io: deps.io,
+          socketState: deps.socketState,
         });
         if (!result.ok) {
           return { content: [{ type: "text" as const, text: result.error }], isError: true };
         }
-        return { content: [{ type: "text" as const, text: JSON.stringify({ ...result, updated: true }, null, 2) }] };
+        // Same whitelist as the create branch below — `ok` is internal.
+        const updatedPayload = {
+          id: result.id,
+          url: result.url,
+          filename: result.filename,
+          totalSlides: result.totalSlides,
+          next: result.next,
+          updated: true,
+        };
+        return { content: [{ type: "text" as const, text: JSON.stringify(updatedPayload, null, 2) }] };
       }
       const userId = await resolveOptionalUserId(supabase, req);
       const result = await createPresentHandoff(supabase, {
@@ -111,7 +135,7 @@ function createPresioMcp(supabase: SupabaseClient, origin: string, req: express.
   return server;
 }
 
-export function registerMcpRoutes(app: express.Express, supabase: SupabaseClient) {
+export function registerMcpRoutes(app: express.Express, supabase: SupabaseClient, deps: McpDeps = {}) {
   app.get("/.well-known/mcp.json", (req, res) => {
     const origin = baseUrl(req);
     res.setHeader("Cache-Control", "public, max-age=300");
@@ -138,7 +162,7 @@ export function registerMcpRoutes(app: express.Express, supabase: SupabaseClient
 
   app.post("/mcp", async (req, res) => {
     const origin = baseUrl(req);
-    const server = createPresioMcp(supabase, origin, req);
+    const server = createPresioMcp(supabase, origin, req, deps);
     try {
       const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
       await server.connect(transport);

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -4,7 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import * as z from "zod/v4";
 import { baseUrl } from "../lib/baseUrl.js";
-import { createPresentHandoff } from "../lib/presentHandoff.js";
+import { createPresentHandoff, updatePresentDeck } from "../lib/presentHandoff.js";
 import { buildCheckReport } from "./check.js";
 import { resolveOptionalUserId } from "../auth.js";
 
@@ -19,7 +19,7 @@ function createPresioMcp(supabase: SupabaseClient, origin: string, req: express.
     {
       title: "Present a PDF",
       description:
-        "Upload a PDF to start a local Presio presentation. Returns a url — open it in a browser to finish handoff (skips share). Same as POST /api/present.",
+        "Upload a PDF to start a local Presio presentation. Returns a url — open it in a browser to finish handoff (skips share). To replace an existing presentation's deck instead of creating one, pass its session_id plus controller_token (the t= parameter of the url from the original create call) and the same link keeps working. Same as POST /api/present.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -29,10 +29,39 @@ function createPresioMcp(supabase: SupabaseClient, origin: string, req: express.
       inputSchema: {
         pdf_base64: z.string().describe("PDF file contents, base64-encoded"),
         filename: z.string().optional().describe("Original filename, e.g. deck.pdf"),
+        session_id: z
+          .string()
+          .optional()
+          .describe("Id of an existing presentation to update in place (from an earlier present response) instead of creating a new one"),
+        controller_token: z
+          .string()
+          .optional()
+          .describe("Controller token for that presentation — the t= query parameter of the url returned when it was created. Required whenever session_id is given."),
       },
     },
-    async ({ pdf_base64, filename }) => {
+    async ({ pdf_base64, filename, session_id, controller_token }) => {
       const buffer = Buffer.from(pdf_base64, "base64");
+      if (session_id) {
+        if (!controller_token) {
+          return {
+            content: [
+              { type: "text" as const, text: "controller_token is required when updating an existing presentation (session_id)." },
+            ],
+            isError: true,
+          };
+        }
+        const result = await updatePresentDeck(supabase, {
+          sessionId: session_id,
+          token: controller_token,
+          buffer,
+          originalName: filename || "",
+          baseUrl: origin,
+        });
+        if (!result.ok) {
+          return { content: [{ type: "text" as const, text: result.error }], isError: true };
+        }
+        return { content: [{ type: "text" as const, text: JSON.stringify({ ...result, updated: true }, null, 2) }] };
+      }
       const userId = await resolveOptionalUserId(supabase, req);
       const result = await createPresentHandoff(supabase, {
         buffer,

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -9,7 +9,7 @@ import { getBearerToken, resolveOptionalUserId, safeEqual } from "../auth.js";
 import { isLocalMode } from "../local/mode.js";
 import { clearSessionState, type SocketState } from "../socket.js";
 import { baseUrl } from "../lib/baseUrl.js";
-import { createPresentHandoff, handoffTokenFrom } from "../lib/presentHandoff.js";
+import { createPresentHandoff, handoffTokenFrom, updatePresentDeck } from "../lib/presentHandoff.js";
 import { generatePassphrase, insertSession, ownedExpiry } from "../lib/sessionRows.js";
 
 export interface RouteDeps {
@@ -56,6 +56,11 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
    *
    *   curl -s -F file=@deck.pdf https://presio.xyz/api/present
    *   # open the returned url
+   *
+   * Update mode: pass `session_id` (multipart field) plus its controller token
+   * (`controller_token` field or `x-controller-token` header) to replace an
+   * existing presentation's deck instead of creating one — the response keeps
+   * the same id/link and no extra concurrent slot is used.
    */
   app.post("/api/present", uploadField("file"), async (req, res) => {
     try {
@@ -66,6 +71,37 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
       }
       if (file.mimetype !== "application/pdf" && !file.originalname.toLowerCase().endsWith(".pdf")) {
         res.status(400).json({ error: "File must be a PDF" });
+        return;
+      }
+
+      const sessionId = typeof req.body.session_id === "string" ? req.body.session_id.trim() : "";
+      if (sessionId) {
+        const token =
+          (typeof req.body.controller_token === "string" && req.body.controller_token) ||
+          req.get("x-controller-token") ||
+          "";
+        if (!token) {
+          // Reject rather than falling back to create: silently minting a new
+          // presentation would hand the agent a fresh link and consume a slot.
+          res.status(401).json({
+            error: 'A controller token is required to update an existing presentation ("controller_token" field or "x-controller-token" header)',
+          });
+          return;
+        }
+        const result = await updatePresentDeck(supabase, {
+          sessionId,
+          token,
+          buffer: file.buffer,
+          originalName: file.originalname,
+          baseUrl: baseUrl(req),
+          io,
+          socketState,
+        });
+        if (!result.ok) {
+          res.status(result.status).json({ error: result.error });
+          return;
+        }
+        res.json({ ...result, updated: true });
         return;
       }
 

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -23,6 +23,19 @@ export interface RouteDeps {
 // not lifetime — presentations.
 export const MAX_CONCURRENT_PRESENTATIONS = 3;
 
+/**
+ * Read a multipart text field that may legitimately appear at most once.
+ * Multer hands a repeated field back as an array, which a bare
+ * `typeof x === "string"` check silently reads as "absent" — on /api/present
+ * that turned a duplicated `session_id` into a brand new presentation, burning
+ * a concurrent slot and handing back a fresh link. `null` means "sent more than
+ * once" so callers can reject instead of guessing which copy was meant.
+ */
+function singleField(value: unknown): string | null {
+  if (value === undefined) return "";
+  return typeof value === "string" ? value : null;
+}
+
 export function registerSessionRoutes(app: express.Express, { supabase, io, socketState }: RouteDeps) {
   const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 50 * 1024 * 1024 } });
 
@@ -74,12 +87,19 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
         return;
       }
 
-      const sessionId = typeof req.body.session_id === "string" ? req.body.session_id.trim() : "";
+      const rawSessionId = singleField(req.body.session_id);
+      const rawToken = singleField(req.body.controller_token);
+      if (rawSessionId === null || rawToken === null) {
+        res.status(400).json({
+          error: 'Send "session_id" and "controller_token" at most once each',
+        });
+        return;
+      }
+
+      const sessionId = rawSessionId.trim();
       if (sessionId) {
-        const token =
-          (typeof req.body.controller_token === "string" && req.body.controller_token) ||
-          req.get("x-controller-token") ||
-          "";
+        // The token is compared byte-for-byte, so it is never trimmed.
+        const token = rawToken || req.get("x-controller-token") || "";
         if (!token) {
           // Reject rather than falling back to create: silently minting a new
           // presentation would hand the agent a fresh link and consume a slot.
@@ -101,7 +121,14 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
           res.status(result.status).json({ error: result.error });
           return;
         }
-        res.json({ ...result, updated: true });
+        res.json({
+          id: result.id,
+          url: result.url,
+          filename: result.filename,
+          totalSlides: result.totalSlides,
+          next: result.next,
+          updated: true,
+        });
         return;
       }
 


### PR DESCRIPTION
Extends the agent-facing present surfaces to update an existing presentation instead of only creating new ones, so an agent iterating on slides no longer mints a fresh presentation — and a fresh link — on every pass.

## API shape

`POST /api/present` gains two optional multipart fields (create behaviour is untouched when they're omitted):

| Field | Meaning |
|---|---|
| `session_id` | Id of an existing presentation to replace |
| `controller_token` | That presentation's controller token — the `t=` query parameter of the `url` returned when it was created (also accepted as the `x-controller-token` header) |

```bash
curl -s -F file=@deck-v2.pdf \
  -F session_id=ABC123 -F controller_token=TOKEN \
  BASE/api/present
# { "id": "ABC123", "url": "BASE/start/ABC123?t=TOKEN", ..., "updated": true }
```

The MCP `present_pdf` tool takes the same flow via optional `session_id` / `controller_token` arguments.

## Behaviour

- **Same link & code** — replacement reuses the session row, so the response returns the original `id`, controller token and handoff url. Local handoff decks are re-staged under their existing object path (restaging under a fresh path if a browser already completed handoff, reviving the link); synced hosted decks are overwritten at their stored path with `deck_updated` broadcast to live viewers and drawings cleared, matching the #17 replace semantics.
- **Auth** — constant-time comparison of the supplied token against the row's token. Wrong or missing token → 401/403; you cannot overwrite someone else's presentation.
- **No silent create** — unknown or expired ids return 404 with a clear error.
- **Quota** — updating never inserts a row, so it consumes no additional concurrent-presentation slot.
- Create path (`no session_id`) is byte-for-byte identical to today's behaviour; token authorization uses the same model as ending/deleting a session.

## Docs

Agent-facing docs updated: `/api.md` (update section + curl example), `/llms-full.txt` (update playbook incl. where the token comes from), agent brief, and the OpenAPI schema.

## Tests

New tests for both surfaces: same-link response, header-token auth, missing/wrong token rejection, unknown/expired 404, deck_updated broadcast on synced decks, "no extra slot" assertions, and unchanged create behaviour. MCP tests exercise the real JSON-RPC tool call through the app router.

Closes #22