### PR TITLE
Show a signed-in user their synced presentations on any device (#15)

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -20,11 +20,14 @@ export function setSessionAuth(id: string, auth: SessionAuth) {
 }
 
 // Ends (deletes) a synced presentation. The server requires the controller
-// token, so send the one stored for this session.
-export function endSession(id: string): Promise<Response> {
+// token, so send the one stored for this session — or `fallbackToken` when this
+// device never held the credential (an account-synced deck opened from
+// /api/sessions/mine carries its token with the row).
+export function endSession(id: string, fallbackToken?: string): Promise<Response> {
   const { controllerToken } = getSessionAuth(id);
+  const token = controllerToken ?? fallbackToken;
   return fetch(`/api/sessions/${id}`, {
     method: "DELETE",
-    headers: controllerToken ? { "x-controller-token": controllerToken } : {},
+    headers: token ? { "x-controller-token": token } : {},
   });
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -12,7 +12,7 @@ import { ConfirmReplaceDialog } from "@/components/controller/ConfirmReplaceDial
 import { ConfirmEndDialog } from "@/components/controller/ConfirmEndDialog";
 import { idbPut, idbList, idbDelete } from "@/lib/localStore";
 import { getSessionAuth, setSessionAuth, endSession } from "@/lib/utils";
-import { lsRemove, annotationsKey } from "@/lib/storage";
+import { lsRemove, annotationsKey, sessionKey } from "@/lib/storage";
 import { track, sha256Hex } from "@/lib/analytics";
 import { loadExternalPdfMeta, createExternalSession } from "@/lib/externalSession";
 import { supabase } from "@/lib/supabaseClient";
@@ -360,8 +360,13 @@ export default function Home() {
           }))
         )
         .catch(() => [] as RecentDeck[]);
-      const controlled = await listControlledSynced();
-      const account = await listAccountSynced();
+      // Independent lookups: the credential scan hits /api/sessions/:id per
+      // stored token, the account list is a single call. Running them together
+      // keeps the slower one off the critical path.
+      const [controlled, account] = await Promise.all([
+        listControlledSynced(),
+        listAccountSynced(),
+      ]);
       if (cancelled) return;
       // Locals first (they carry a creation date), then synced decks this
       // browser holds credentials for, then the account's remaining synced
@@ -392,7 +397,9 @@ export default function Home() {
   const openRecent = useCallback(
     (r: RecentDeck) => {
       if (r.kind === "account" && r.controllerToken) {
-        setSessionAuth(r.id, { controllerToken: r.controllerToken });
+        // Spread what's already stored: setSessionAuth writes the whole record,
+        // so assigning a bare { controllerToken } would drop a passphrase.
+        setSessionAuth(r.id, { ...getSessionAuth(r.id), controllerToken: r.controllerToken });
       }
       navigate(`/s/${r.id}?role=controller`);
     },
@@ -412,6 +419,16 @@ export default function Home() {
     try {
       if (closeTarget.kind === "local") {
         await idbDelete(closeTarget.id);
+        // A local session is presented from two windows in the same browser;
+        // the viewer has no server to hear from, so tell it directly on the
+        // channel Presentation listens on. Same message endPresentation sends.
+        try {
+          const channel = new BroadcastChannel(`presio-${closeTarget.id}`);
+          channel.postMessage({ type: "session_ended" });
+          channel.close();
+        } catch {
+          // No BroadcastChannel (or it's blocked): the deck is gone either way.
+        }
       } else {
         const res = await endSession(closeTarget.id, closeTarget.controllerToken);
         if (!res.ok) {
@@ -420,11 +437,14 @@ export default function Home() {
         }
       }
       // The stored controller credential is dead weight either way.
-      lsRemove(`session_${closeTarget.id}`);
+      lsRemove(sessionKey(closeTarget.id));
       setRecents((rs) => rs.filter((r) => r.id !== closeTarget.id));
       setCloseTarget(null);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to close the presentation");
+      // Dismiss the dialog too: the error renders on the page behind it, so
+      // leaving it up looks like the button simply did nothing.
+      setCloseTarget(null);
     } finally {
       setClosing(false);
     }
@@ -468,7 +488,9 @@ export default function Home() {
         if (!controllerToken) {
           throw new Error("This browser isn't the controller for this presentation");
         }
-        if (!stored.controllerToken) setSessionAuth(replaceTarget.id, { controllerToken });
+        if (!stored.controllerToken) {
+          setSessionAuth(replaceTarget.id, { ...stored, controllerToken });
+        }
         const headers: Record<string, string> = { "x-controller-token": controllerToken };
         const { data: sessionData } = await supabase.auth.getSession();
         if (sessionData.session) {
@@ -839,21 +861,20 @@ export default function Home() {
                   </div>
                   <ul className="space-y-1.5">
                     {recents.map((r) => (
+                      // The open action is its own button rather than a
+                      // clickable row: nesting Replace/Close inside a
+                      // `role="button"` row is invalid ARIA, and Enter/Space on
+                      // an inner button would activate both it and the row.
                       <li
                         key={r.id}
-                        role="button"
-                        tabIndex={0}
-                        aria-label={`Open ${r.filename}`}
-                        onClick={() => openRecent(r)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            openRecent(r);
-                          }
-                        }}
-                        className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 transition-colors hover:border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home2-accent)]"
+                        className="flex items-center gap-2 rounded-md border px-3 py-2 transition-colors focus-within:border-muted-foreground/50 hover:border-muted-foreground/50"
                       >
-                        <div className="min-w-0 flex-1">
+                        <button
+                          type="button"
+                          aria-label={`Open ${r.filename}`}
+                          onClick={() => openRecent(r)}
+                          className="min-w-0 flex-1 cursor-pointer rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home2-accent)]"
+                        >
                           <p className="truncate text-sm font-medium">{r.filename}</p>
                           <p className="text-xs text-muted-foreground">
                             {r.totalSlides} {r.totalSlides === 1 ? "slide" : "slides"}
@@ -865,16 +886,13 @@ export default function Home() {
                             </span>
                             {r.createdAt !== null && ` · ${formatRecentDate(r.createdAt)}`}
                           </p>
-                        </div>
+                        </button>
                         <Button
                           size="sm"
                           variant="ghost"
                           title="Swap in a recompiled PDF — keeps this presentation's code"
                           disabled={replacing}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            pickReplace(r);
-                          }}
+                          onClick={() => pickReplace(r)}
                         >
                           <RefreshCw size={14} />
                           Replace
@@ -882,12 +900,13 @@ export default function Home() {
                         <Button
                           size="sm"
                           variant="ghost"
-                          title="End this presentation for everyone — cannot be undone"
+                          title={
+                            r.kind === "local"
+                              ? "Delete this presentation from this browser — cannot be undone"
+                              : "End this presentation for everyone — cannot be undone"
+                          }
                           disabled={closing}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setCloseTarget(r);
-                          }}
+                          onClick={() => setCloseTarget(r)}
                         >
                           <X size={14} />
                           Close

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -10,7 +10,7 @@ import { MobileNotice } from "@/components/MobileNotice";
 import { CodeBlock } from "@/components/CodeBlock";
 import { ConfirmReplaceDialog } from "@/components/controller/ConfirmReplaceDialog";
 import { ConfirmEndDialog } from "@/components/controller/ConfirmEndDialog";
-import { idbPut, idbList } from "@/lib/localStore";
+import { idbPut, idbList, idbDelete } from "@/lib/localStore";
 import { getSessionAuth, setSessionAuth, endSession } from "@/lib/utils";
 import { lsRemove, annotationsKey } from "@/lib/storage";
 import { track, sha256Hex } from "@/lib/analytics";
@@ -399,18 +399,27 @@ export default function Home() {
     [navigate]
   );
 
-  // Close (end) a presentation for everyone. Not recoverable — the server
-  // marks the row expired and drops its PDF — hence the confirm dialog.
+  // Close (end) a presentation. A local deck's PDF only ever lived in this
+  // browser, so ending it means deleting that IndexedDB copy — the same
+  // teardown the controller runs in Presentation.tsx. A synced deck is ended
+  // for everyone on the server: viewers are disconnected, the stored PDF is
+  // dropped and the row is marked expired. Neither is recoverable, hence the
+  // confirm dialog.
   const confirmClose = useCallback(async () => {
     if (!closeTarget || closing) return;
     setClosing(true);
     setError("");
     try {
-      const res = await endSession(closeTarget.id, closeTarget.controllerToken);
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || "Failed to close the presentation");
+      if (closeTarget.kind === "local") {
+        await idbDelete(closeTarget.id);
+      } else {
+        const res = await endSession(closeTarget.id, closeTarget.controllerToken);
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || "Failed to close the presentation");
+        }
       }
+      // The stored controller credential is dead weight either way.
       lsRemove(`session_${closeTarget.id}`);
       setRecents((rs) => rs.filter((r) => r.id !== closeTarget.id));
       setCloseTarget(null);
@@ -852,7 +861,7 @@ export default function Home() {
                             <span
                               className={r.kind === "local" ? undefined : "text-(--home2-accent)"}
                             >
-                              {r.kind === "local" ? "local" : r.kind === "synced" ? "shared" : "Synced"}
+                              {r.kind === "local" ? "local" : r.kind === "synced" ? "shared" : "synced"}
                             </span>
                             {r.createdAt !== null && ` · ${formatRecentDate(r.createdAt)}`}
                           </p>
@@ -1097,7 +1106,7 @@ Hello world.
 
       {closeTarget && (
         <ConfirmEndDialog
-          local={false}
+          local={closeTarget.kind === "local"}
           onConfirm={confirmClose}
           onClose={() => setCloseTarget(null)}
         />

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { getDocument } from "pdfjs-dist";
-import { ExternalLink, RefreshCw } from "lucide-react";
+import { ExternalLink, RefreshCw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { AccountControl } from "@/components/AccountControl";
@@ -9,12 +9,14 @@ import { PresioLogo } from "@/components/PresioLogo";
 import { MobileNotice } from "@/components/MobileNotice";
 import { CodeBlock } from "@/components/CodeBlock";
 import { ConfirmReplaceDialog } from "@/components/controller/ConfirmReplaceDialog";
+import { ConfirmEndDialog } from "@/components/controller/ConfirmEndDialog";
 import { idbPut, idbList } from "@/lib/localStore";
-import { getSessionAuth, setSessionAuth } from "@/lib/utils";
+import { getSessionAuth, setSessionAuth, endSession } from "@/lib/utils";
 import { lsRemove, annotationsKey } from "@/lib/storage";
 import { track, sha256Hex } from "@/lib/analytics";
 import { loadExternalPdfMeta, createExternalSession } from "@/lib/externalSession";
 import { supabase } from "@/lib/supabaseClient";
+import { useAuth } from "@/lib/useAuth";
 import "@/lib/pdf"; // ensure pdf.js worker is configured
 
 const TYPST_PACKAGE_URL = "https://github.com/benedict-armstrong/presio-typst-package";
@@ -231,14 +233,18 @@ function formatRecentDate(ts: number): string {
 // decks come from IndexedDB; synced ones are discovered through the controller
 // credentials this browser holds (created+synced here, or taken over via
 // passphrase) — the IndexedDB record is deleted on claim, so without the
-// credential scan a shared deck would vanish from the list.
+// credential scan a shared deck would vanish from the list. Account decks come
+// from the signed-in user's server-side list, so they show up on any device
+// they sign in on, with the controller token the server legitimately holds.
 interface RecentDeck {
   id: string;
   filename: string;
   totalSlides: number;
   /** Present only for local decks (IndexedDB creation time). */
   createdAt: number | null;
-  kind: "local" | "synced";
+  kind: "local" | "synced" | "account";
+  /** Account decks only: the controller token returned by /api/sessions/mine. */
+  controllerToken?: string;
 }
 
 const SESSION_KEY_RE = /^session_([A-Z0-9]{6})$/;
@@ -282,8 +288,40 @@ async function listControlledSynced(): Promise<RecentDeck[]> {
   return out;
 }
 
+// Decks the signed-in account owns server-side. Anonymous visitors must make
+// zero extra network round-trips, so the fetch is skipped entirely when no
+// session token exists — signing out drops the list back to local-only for free.
+async function listAccountSynced(): Promise<RecentDeck[]> {
+  const { data } = await supabase.auth.getSession();
+  const token = data.session?.access_token;
+  if (!token) return [];
+  try {
+    const res = await fetch("/api/sessions/mine", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return [];
+    const rows = (await res.json()) as {
+      id: string;
+      filename: string;
+      total_slides: number;
+      controllerToken: string;
+    }[];
+    return rows.map((row) => ({
+      id: row.id,
+      filename: row.filename,
+      totalSlides: row.total_slides,
+      createdAt: null,
+      kind: "account",
+      controllerToken: row.controllerToken,
+    }));
+  } catch {
+    return []; // offline or server unreachable: skip rather than block the page
+  }
+}
+
 export default function Home() {
   const navigate = useNavigate();
+  const { user } = useAuth();
   const [dragging, setDragging] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -305,6 +343,8 @@ export default function Home() {
   const [replaceTarget, setReplaceTarget] = useState<RecentDeck | null>(null);
   const [replaceFile, setReplaceFile] = useState<File | null>(null);
   const [replacing, setReplacing] = useState(false);
+  const [closeTarget, setCloseTarget] = useState<RecentDeck | null>(null);
+  const [closing, setClosing] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -321,11 +361,14 @@ export default function Home() {
         )
         .catch(() => [] as RecentDeck[]);
       const controlled = await listControlledSynced();
+      const account = await listAccountSynced();
       if (cancelled) return;
       // Locals first (they carry a creation date), then synced decks this
-      // browser holds credentials for; dedupe by id, preferring the local copy.
+      // browser holds credentials for, then the account's remaining synced
+      // decks (visible from any device); dedupe by id, preferring the earlier
+      // kind — local > locally-controlled synced > account-only.
       const byId = new Map<string, RecentDeck>();
-      for (const deck of [...locals, ...controlled]) {
+      for (const deck of [...locals, ...controlled, ...account]) {
         if (!byId.has(deck.id)) byId.set(deck.id, deck);
       }
       setRecents([...byId.values()]);
@@ -333,13 +376,50 @@ export default function Home() {
     return () => {
       cancelled = true;
     };
-  }, [uploading]);
+    // Re-listing on the user id means signing in pulls the account's decks in
+    // and signing out drops back to local-only.
+  }, [uploading, user?.id]);
 
   const pickReplace = useCallback((target: RecentDeck) => {
     setReplaceFile(null);
     setReplaceTarget(target);
     replaceInputRef.current?.click();
   }, []);
+
+  // The whole recents row opens its controller. An account-only deck has never
+  // been opened on this device, so persist the controller token the server
+  // returned first — the socket join and the replace endpoint authorize with it.
+  const openRecent = useCallback(
+    (r: RecentDeck) => {
+      if (r.kind === "account" && r.controllerToken) {
+        setSessionAuth(r.id, { controllerToken: r.controllerToken });
+      }
+      navigate(`/s/${r.id}?role=controller`);
+    },
+    [navigate]
+  );
+
+  // Close (end) a presentation for everyone. Not recoverable — the server
+  // marks the row expired and drops its PDF — hence the confirm dialog.
+  const confirmClose = useCallback(async () => {
+    if (!closeTarget || closing) return;
+    setClosing(true);
+    setError("");
+    try {
+      const res = await endSession(closeTarget.id, closeTarget.controllerToken);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Failed to close the presentation");
+      }
+      lsRemove(`session_${closeTarget.id}`);
+      setRecents((rs) => rs.filter((r) => r.id !== closeTarget.id));
+      setCloseTarget(null);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to close the presentation");
+    } finally {
+      setClosing(false);
+    }
+  }, [closeTarget, closing]);
 
   const confirmReplace = useCallback(async () => {
     if (!replaceTarget || !replaceFile || replacing) return;
@@ -370,12 +450,16 @@ export default function Home() {
         }
       } else {
         // Synced deck: overwrite its server copy. The controller token this
-        // browser holds authorizes the write; a logged-in owner token is
-        // attached too when present (the server accepts either).
-        const { controllerToken } = getSessionAuth(replaceTarget.id);
+        // browser holds authorizes the write — for an account deck this device
+        // never controlled, fall back to the token /api/sessions/mine returned.
+        // A logged-in owner token is attached too when present (the server
+        // accepts either).
+        const stored = getSessionAuth(replaceTarget.id);
+        const controllerToken = stored.controllerToken ?? replaceTarget.controllerToken;
         if (!controllerToken) {
           throw new Error("This browser isn't the controller for this presentation");
         }
+        if (!stored.controllerToken) setSessionAuth(replaceTarget.id, { controllerToken });
         const headers: Record<string, string> = { "x-controller-token": controllerToken };
         const { data: sessionData } = await supabase.auth.getSession();
         if (sessionData.session) {
@@ -748,7 +832,17 @@ export default function Home() {
                     {recents.map((r) => (
                       <li
                         key={r.id}
-                        className="flex items-center gap-2 rounded-md border px-3 py-2"
+                        role="button"
+                        tabIndex={0}
+                        aria-label={`Open ${r.filename}`}
+                        onClick={() => openRecent(r)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            openRecent(r);
+                          }
+                        }}
+                        className="flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 transition-colors hover:border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--home2-accent)]"
                       >
                         <div className="min-w-0 flex-1">
                           <p className="truncate text-sm font-medium">{r.filename}</p>
@@ -756,29 +850,38 @@ export default function Home() {
                             {r.totalSlides} {r.totalSlides === 1 ? "slide" : "slides"}
                             {" · "}
                             <span
-                              className={r.kind === "synced" ? "text-(--home2-accent)" : undefined}
+                              className={r.kind === "local" ? undefined : "text-(--home2-accent)"}
                             >
-                              {r.kind === "synced" ? "shared" : "local"}
+                              {r.kind === "local" ? "local" : r.kind === "synced" ? "shared" : "Synced"}
                             </span>
                             {r.createdAt !== null && ` · ${formatRecentDate(r.createdAt)}`}
                           </p>
                         </div>
                         <Button
                           size="sm"
-                          variant="outline"
-                          onClick={() => navigate(`/s/${r.id}?role=controller`)}
+                          variant="ghost"
+                          title="Swap in a recompiled PDF — keeps this presentation's code"
+                          disabled={replacing}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            pickReplace(r);
+                          }}
                         >
-                          Open
+                          <RefreshCw size={14} />
+                          Replace
                         </Button>
                         <Button
                           size="sm"
                           variant="ghost"
-                          title="Swap in a recompiled PDF — keeps this presentation's code"
-                          disabled={replacing}
-                          onClick={() => pickReplace(r)}
+                          title="End this presentation for everyone — cannot be undone"
+                          disabled={closing}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setCloseTarget(r);
+                          }}
                         >
-                          <RefreshCw size={14} />
-                          Replace
+                          <X size={14} />
+                          Close
                         </Button>
                       </li>
                     ))}
@@ -989,6 +1092,14 @@ Hello world.
         <ConfirmReplaceDialog
           onConfirm={confirmReplace}
           onClose={() => { setReplaceTarget(null); setReplaceFile(null); }}
+        />
+      )}
+
+      {closeTarget && (
+        <ConfirmEndDialog
+          local={false}
+          onConfirm={confirmClose}
+          onClose={() => setCloseTarget(null)}
         />
       )}
 

--- a/server/agent/content/api.md
+++ b/server/agent/content/api.md
@@ -2,7 +2,7 @@
 title: Presio API
 description: REST reference for starting local PDF presentations and validating sidecars, with curl examples.
 canonical: BASE/api.md
-last_updated: 2026-08-27
+last_updated: 2026-08-28
 ---
 
 # Presio API
@@ -64,6 +64,12 @@ curl -s -F file=@deck.pdf BASE/api/check
 
 - `GET /api/sessions/:id/handoff?t=TOKEN` — download staged PDF
 - `POST /api/sessions/:id/handoff/complete` — header `x-controller-token` — clear server copy
+
+## Account presentations
+
+- `GET /api/sessions/mine` — header `Authorization: Bearer <login JWT>` — the signed-in user's live synced presentations, newest first.
+  **200:** `[{ id, filename, total_slides, created_at, expires_at, controllerToken }]`. `controllerToken` is included because the owner is entitled to it — it lets any device the user signs in on open the presentation as its controller. 401 without a valid token; not available in local mode.
+- `DELETE /api/sessions/:id` — header `x-controller-token` — end a presentation: viewers are disconnected, the PDF is removed, and the row is marked expired (not recoverable).
 
 ## OpenAPI
 

--- a/server/agent/openapi.ts
+++ b/server/agent/openapi.ts
@@ -152,6 +152,77 @@ export function buildOpenApi(base: string) {
           },
         },
       },
+      "/api/sessions/mine": {
+        get: {
+          summary: "List the signed-in user's live synced presentations",
+          description:
+            "Every non-expired synced presentation owned by the authenticated user, newest first. Each row carries its controller token — the owner is entitled to it, so any device the user signs in on can open the controller. Not available in local mode.",
+          operationId: "mySessions",
+          parameters: [
+            {
+              name: "Authorization",
+              in: "header",
+              required: true,
+              schema: { type: "string" },
+              description: "Bearer Presio login JWT",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Live synced presentations, newest first",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      required: ["id", "filename", "total_slides", "controllerToken"],
+                      properties: {
+                        id: { type: "string" },
+                        filename: { type: "string" },
+                        total_slides: { type: "integer" },
+                        created_at: { type: "string", format: "date-time" },
+                        expires_at: { type: "string", format: "date-time" },
+                        controllerToken: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "Missing or invalid bearer token" },
+          },
+        },
+      },
+      "/api/sessions/{id}": {
+        delete: {
+          summary: "End a presentation",
+          description:
+            "Disconnects all viewers, removes the PDF, and marks the session expired — not recoverable. Authorized by the presentation's controller token.",
+          operationId: "endSession",
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" } },
+            {
+              name: "x-controller-token",
+              in: "header",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "OK",
+              content: {
+                "application/json": {
+                  schema: { type: "object", properties: { ok: { type: "boolean" } } },
+                },
+              },
+            },
+            "403": { description: "Wrong controller token" },
+            "404": { description: "Unknown session id" },
+          },
+        },
+      },
     },
   };
 }

--- a/server/rest.test.ts
+++ b/server/rest.test.ts
@@ -434,3 +434,75 @@ describe("POST /api/present (update in place)", () => {
     expect(res.body.next).not.toMatch(/hand off/i);
   });
 });
+
+describe("GET /api/sessions/mine (account list)", () => {
+  const owned = (over: Partial<SessionRow>): SessionRow =>
+    baseRow({ user_id: "user-1", created_at: "2026-08-01T00:00:00.000Z", ...over });
+
+  it("401s without a bearer token", async () => {
+    const app = appWith(new FakeSupabase([owned({})]));
+    const res = await request(app).get("/api/sessions/mine");
+    expect(res.status).toBe(401);
+  });
+
+  it("401s on an unrecognised bearer token", async () => {
+    const app = appWith(new FakeSupabase([owned({})]).addToken("good", "user-1"));
+    const res = await request(app)
+      .get("/api/sessions/mine")
+      .set("Authorization", "Bearer nope");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns only the caller's rows, never another account's", async () => {
+    const fake = new FakeSupabase([
+      owned({ id: "MINE01" }),
+      owned({ id: "THEIR1", user_id: "user-2" }),
+    ]).addToken("tok", "user-1");
+    const res = await request(appWith(fake))
+      .get("/api/sessions/mine")
+      .set("Authorization", "Bearer tok");
+    expect(res.status).toBe(200);
+    expect(res.body.map((r: { id: string }) => r.id)).toEqual(["MINE01"]);
+  });
+
+  it("excludes local, expired and past-expiry rows", async () => {
+    const past = new Date(Date.now() - 86_400_000).toISOString();
+    const fake = new FakeSupabase([
+      owned({ id: "LIVE01" }),
+      owned({ id: "LOCAL1", local: true }),
+      owned({ id: "ENDED1", status: "expired" }),
+      owned({ id: "STALE1", expires_at: past }),
+    ]).addToken("tok", "user-1");
+    const res = await request(appWith(fake))
+      .get("/api/sessions/mine")
+      .set("Authorization", "Bearer tok");
+    expect(res.status).toBe(200);
+    expect(res.body.map((r: { id: string }) => r.id)).toEqual(["LIVE01"]);
+  });
+
+  it("orders newest first", async () => {
+    const fake = new FakeSupabase([
+      owned({ id: "OLD001", created_at: "2026-01-01T00:00:00.000Z" }),
+      owned({ id: "NEW001", created_at: "2026-08-20T00:00:00.000Z" }),
+      owned({ id: "MID001", created_at: "2026-05-05T00:00:00.000Z" }),
+    ]).addToken("tok", "user-1");
+    const res = await request(appWith(fake))
+      .get("/api/sessions/mine")
+      .set("Authorization", "Bearer tok");
+    expect(res.body.map((r: { id: string }) => r.id)).toEqual(["NEW001", "MID001", "OLD001"]);
+  });
+
+  it("returns the whitelisted fields — the controller token, and no passphrase", async () => {
+    const fake = new FakeSupabase([owned({})]).addToken("tok", "user-1");
+    const res = await request(appWith(fake))
+      .get("/api/sessions/mine")
+      .set("Authorization", "Bearer tok");
+    expect(res.body).toHaveLength(1);
+    // The owner is entitled to the controller token: it's what lets a device
+    // they've just signed in on open the presentation as its controller.
+    expect(res.body[0].controllerToken).toBe("secret-token");
+    expect(Object.keys(res.body[0]).sort()).toEqual(
+      ["controllerToken", "created_at", "expires_at", "filename", "id", "total_slides"]
+    );
+  });
+});

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -5,7 +5,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { nanoid } from "nanoid";
 import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
 import { isValidHttpsUrl, isValidTotalSlides, MAX_TOTAL_SLIDES } from "../validation.js";
-import { getBearerToken, resolveOptionalUserId, safeEqual } from "../auth.js";
+import { getBearerToken, requireUser, resolveOptionalUserId, safeEqual } from "../auth.js";
 import { isLocalMode } from "../local/mode.js";
 import { clearSessionState, type SocketState } from "../socket.js";
 import { baseUrl } from "../lib/baseUrl.js";
@@ -155,6 +155,55 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
       res.status(500).json({ error: "Internal server error" });
     }
   });
+
+  /**
+   * GET /api/sessions/mine — the signed-in account's live synced presentations,
+   * newest first. The home screen asks this on any device the user signs in on:
+   * local decks are device-bound IndexedDB, but synced ones belong to the
+   * account, so a new device needs this list (plus each deck's controller
+   * token — the owner is entitled to it, and without it the device could never
+   * open the controller). Local handoff rows are excluded: their PDF only ever
+   * belongs in the creating browser.
+   */
+  if (!isLocalMode) {
+    app.get("/api/sessions/mine", async (req, res) => {
+      try {
+        const user = await requireUser(supabase, req);
+        if (!user) {
+          res.status(401).json({ error: "Authentication required" });
+          return;
+        }
+        // The filter comes from the verified token only — a client-supplied id
+        // is never trusted, so no account can see another's rows.
+        const { data, error } = await supabase
+          .from("sessions")
+          .select("id, filename, total_slides, created_at, expires_at, controller_token")
+          .eq("user_id", user.id)
+          .eq("local", false)
+          .neq("status", "expired")
+          .gt("expires_at", new Date().toISOString())
+          .order("created_at", { ascending: false });
+        if (error) {
+          res.status(500).json({ error: "Failed to list presentations" });
+          return;
+        }
+        // Whitelist the response fields; only controller_token is renamed.
+        res.json(
+          (data ?? []).map((row) => ({
+            id: row.id,
+            filename: row.filename,
+            total_slides: row.total_slides,
+            created_at: row.created_at,
+            expires_at: row.expires_at,
+            controllerToken: row.controller_token,
+          }))
+        );
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: "Internal server error" });
+      }
+    });
+  }
 
   // Download a staged handoff PDF (token required). Does not delete yet.
   app.get("/api/sessions/:id/handoff", async (req, res) => {

--- a/server/test/fakeSupabase.ts
+++ b/server/test/fakeSupabase.ts
@@ -42,6 +42,7 @@ class Query<T = unknown> implements PromiseLike<T> {
   private filters: Filter[] = [];
   private wantSingle = false;
   private wantCount = false;
+  private orderSpec?: { col: string; ascending: boolean };
 
   constructor(
     private rows: SessionRow[],
@@ -58,10 +59,22 @@ class Query<T = unknown> implements PromiseLike<T> {
   gt(col: string, val: unknown) { this.filters.push({ col, op: "gt", val }); return this; }
   lt(col: string, val: unknown) { this.filters.push({ col, op: "lt", val }); return this; }
   in(col: string, val: unknown[]) { this.filters.push({ col, op: "in", val }); return this; }
+  order(col: string, opts?: { ascending?: boolean }) {
+    this.orderSpec = { col, ascending: opts?.ascending ?? true };
+    return this;
+  }
   single() { this.wantSingle = true; return this; }
 
   private matched(): SessionRow[] {
-    return this.rows.filter((r) => this.filters.every((f) => matches(r, f)));
+    const matched = this.rows.filter((r) => this.filters.every((f) => matches(r, f)));
+    if (this.orderSpec) {
+      const { col, ascending } = this.orderSpec;
+      matched.sort((a, b) => {
+        const cmp = a[col] === b[col] ? 0 : (a[col] as never) > (b[col] as never) ? 1 : -1;
+        return ascending ? cmp : -cmp;
+      });
+    }
+    return matched;
   }
 
   private run(): unknown {


### PR DESCRIPTION
Closes #15

## What
- `GET /api/sessions/mine` (requireUser auth, local-mode skipped): non-expired, non-local rows owned by the verified token's user, newest first, returning a whitelisted field set including `controllerToken` (the owner is entitled to it). Never trusts a client-supplied user id — no cross-account leakage.
- Home recents now merge three sources with dedupe priority local > locally-controlled synced > account-only. Fetch is skipped entirely when there's no Supabase session (zero extra round-trips for signed-out visitors), and the recents effect re-runs on auth change, so signing out drops back to local-only automatically.
- The whole list item is the open button; `account` rows call `setSessionAuth()` with the returned controller token before navigating, so opening on a brand-new device authorizes as today. Account rows carry a "Synced" marker.
- Per-item **Close** action with a confirm (not recoverable) using the existing `DELETE /api/sessions/:id`; documented `/mine` in api.md + openapi.

## Decisions / assumptions
- Reused the pre-existing `DELETE /api/sessions/:id` (controller-token gated) for Close rather than adding a user-owned endpoint — it already marks the row expired, removes the PDF and disconnects viewers, and isn't guessable by id alone.
- `FakeSupabase` gained `.order()` support since the new route sorts server-side.
- Response fields are explicitly whitelisted rather than spread.
- Controller's "Replace" branch check is effectively `!== "local"`, so account-only rows can replace too.

## Verification
Client: `tsc -b`, `eslint`, vitest 30/30. Server: vitest 45/45 + smoke-tested `/mine` auth/ownership/expiry filtering.