### PR TITLE
Detect a re-upload on drop and offer update instead of create (#19)

### DIFF
--- a/client/src/components/controller/ConfirmReuploadDialog.tsx
+++ b/client/src/components/controller/ConfirmReuploadDialog.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@/components/ui/button";
+import { DialogOverlay } from "@/components/ui/dialog-overlay";
+
+// "Looks like a re-upload" prompt shown by the home screen when a dropped or
+// browsed PDF matches a presentation this browser already knows about. Offers
+// to swap the new bytes in under the same code (the default) or to create a
+// separate presentation. Never shown for an explicit replace — the controller's
+// "Replace PDF…" and the recents list' Replace button are already deliberate.
+export function ConfirmReuploadDialog({
+  filename,
+  code,
+  compared,
+  onUpdate,
+  onCreate,
+  onClose,
+}: {
+  filename: string;
+  code: string;
+  /** Whether the file's bytes were actually compared against the stored copy
+   * (local decks only). Synced/account decks match on name alone, so the copy
+   * mustn't claim the content differs. */
+  compared: boolean;
+  onUpdate: () => void;
+  onCreate: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <DialogOverlay onClose={onClose}>
+      <div className="space-y-2 text-center">
+        <h2 className="text-lg font-semibold">
+          Update &quot;{filename}&quot;?
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          You already have a presentation with this name
+          {compared && " and the new file holds different content"}. Updating
+          replaces it and keeps the code {code}, so the existing link stays
+          live — or create it as a separate presentation.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Button className="flex-1" variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button className="flex-1" variant="outline" onClick={onCreate}>
+          Create separate
+        </Button>
+        <Button className="flex-1" autoFocus onClick={onUpdate}>
+          Update
+        </Button>
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/client/src/lib/localStore.ts
+++ b/client/src/lib/localStore.ts
@@ -2,7 +2,7 @@
 // uploaded to the server. Shared across same-origin tabs/windows.
 
 const DB_NAME = "presio";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE = "presentations";
 
 export interface LocalPresentation {
@@ -10,6 +10,9 @@ export interface LocalPresentation {
   filename: string;
   totalSlides: number;
   blob: Blob;
+  /** SHA-256 hex of the stored PDF's bytes, when known. Optional: records
+   * created before v2 have no hash. */
+  sha256?: string;
   createdAt: number;
 }
 
@@ -62,7 +65,13 @@ export function idbDelete(id: string): Promise<void> {
 export function idbList(): Promise<LocalPresentationMeta[]> {
   return tx<LocalPresentation[]>("readonly", (store) => store.getAll()).then((recs) =>
     recs
-      .map((r) => ({ id: r.id, filename: r.filename, totalSlides: r.totalSlides, createdAt: r.createdAt }))
+      .map((r) => ({
+        id: r.id,
+        filename: r.filename,
+        totalSlides: r.totalSlides,
+        sha256: r.sha256,
+        createdAt: r.createdAt,
+      }))
       .sort((a, b) => b.createdAt - a.createdAt)
   );
 }

--- a/client/src/lib/localStore.ts
+++ b/client/src/lib/localStore.ts
@@ -22,7 +22,7 @@ let dbPromise: Promise<IDBDatabase> | null = null;
 
 function openDb(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise;
-  dbPromise = new Promise((resolve, reject) => {
+  const attempt = new Promise<IDBDatabase>((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
@@ -30,10 +30,36 @@ function openDb(): Promise<IDBDatabase> {
         db.createObjectStore(STORE, { keyPath: "id" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    // A presentation runs as two windows in this browser (controller + viewer),
+    // so on the deploy that raises DB_VERSION one of them will still hold a
+    // connection at the old version and block the upgrade. Without these two
+    // handlers `open` neither succeeds nor errors and every caller hangs
+    // forever: `onblocked` turns the deadlock into a message the UI can show,
+    // and `onversionchange` makes *this* connection step aside when some other
+    // window is the one upgrading.
+    req.onblocked = () =>
+      reject(
+        new Error(
+          "Presio was updated. Please close this presentation's other windows/tabs and reload."
+        )
+      );
+    req.onsuccess = () => {
+      const db = req.result;
+      db.onversionchange = () => {
+        db.close();
+        dbPromise = null; // force a reopen (at the new version) on next use
+      };
+      resolve(db);
+    };
     req.onerror = () => reject(req.error);
   });
-  return dbPromise;
+  // Never cache a failed open: whatever blocked it (another window still on
+  // the old version) normally clears, and the next call should try again.
+  attempt.catch(() => {
+    if (dbPromise === attempt) dbPromise = null;
+  });
+  dbPromise = attempt;
+  return attempt;
 }
 
 function tx<T>(mode: IDBTransactionMode, run: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {

--- a/client/src/lib/pdf.test.ts
+++ b/client/src/lib/pdf.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest";
+import { freshPdfUrl } from "@/lib/pdf";
+
+// A replace rewrites a synced deck's stored object in place, so the URL is the
+// same before and after. Every load that must not serve the previous deck goes
+// through freshPdfUrl.
+describe("freshPdfUrl", () => {
+  it("adds the version as the first query parameter", () => {
+    expect(freshPdfUrl("https://storage.test/ABC123.pdf", 1234)).toBe(
+      "https://storage.test/ABC123.pdf?v=1234"
+    );
+  });
+
+  it("appends to a URL that already carries a query string", () => {
+    expect(freshPdfUrl("https://storage.test/ABC123.pdf?token=xyz", 1234)).toBe(
+      "https://storage.test/ABC123.pdf?token=xyz&v=1234"
+    );
+  });
+
+  it("is stable for the same version, so a page reload reuses the fetch", () => {
+    const url = "https://storage.test/ABC123.pdf";
+    expect(freshPdfUrl(url, 99)).toBe(freshPdfUrl(url, 99));
+  });
+
+  it("differs once the version does, so new bytes are actually fetched", () => {
+    const url = "https://storage.test/ABC123.pdf";
+    expect(freshPdfUrl(url, 1)).not.toBe(freshPdfUrl(url, 2));
+  });
+});

--- a/client/src/lib/pdf.ts
+++ b/client/src/lib/pdf.ts
@@ -39,6 +39,18 @@ export async function loadPdfData(data: Uint8Array): Promise<PDFDocumentProxy> {
   return getDocument({ data }).promise;
 }
 
+/**
+ * A URL that fetches a synced deck's *current* bytes.
+ *
+ * A replace rewrites the stored object in place, so the deck's URL never
+ * changes — and a browser (or the CDN in front of it) that already has the old
+ * copy will happily serve it again. Every load that must not get the previous
+ * deck goes through here, keyed by something that changes when the bytes do.
+ */
+export function freshPdfUrl(url: string, version: string | number): string {
+  return `${url}${url.includes("?") ? "&" : "?"}v=${version}`;
+}
+
 // Cap the rendered canvas width (device pixels). Beyond ~4K wide there's no
 // visible gain and we risk hitting browser canvas-size limits / memory.
 const MAX_CANVAS_WIDTH = 4096;

--- a/client/src/lib/reupload.test.ts
+++ b/client/src/lib/reupload.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LocalPresentation } from "@/lib/localStore";
+
+// The matcher reads (and backfills) fingerprints through the IndexedDB store,
+// which doesn't exist under the node test environment. Stand in a plain map so
+// the tests exercise the matching rules rather than the browser API.
+const records = new Map<string, LocalPresentation>();
+const idbGet = vi.fn(async (id: string) => records.get(id) ?? null);
+const idbPut = vi.fn(async (rec: LocalPresentation) => {
+  records.set(rec.id, rec);
+});
+vi.mock("@/lib/localStore", () => ({
+  idbGet: (id: string) => idbGet(id),
+  idbPut: (rec: LocalPresentation) => idbPut(rec),
+}));
+
+const { matchReupload } = await import("@/lib/reupload");
+const { sha256Hex } = await import("@/lib/analytics");
+
+const bytes = (text: string) => new TextEncoder().encode(text);
+const hashOf = (text: string) => sha256Hex(bytes(text).buffer as ArrayBuffer);
+
+const local = (id: string, filename: string, sha256?: string) =>
+  ({ id, filename, kind: "local" as const, sha256 });
+const synced = (id: string, filename: string) =>
+  ({ id, filename, kind: "synced" as const });
+const account = (id: string, filename: string) =>
+  ({ id, filename, kind: "account" as const });
+
+function seedRecord(id: string, text: string) {
+  records.set(id, {
+    id,
+    filename: id,
+    totalSlides: 1,
+    blob: new Blob([bytes(text)]),
+    createdAt: 0,
+  } as LocalPresentation);
+}
+
+beforeEach(() => {
+  records.clear();
+  idbGet.mockClear();
+  idbPut.mockClear();
+});
+
+describe("matchReupload", () => {
+  it("returns nothing when no recent shares the filename", async () => {
+    const hash = await hashOf("deck");
+    expect(await matchReupload("Talk", hash, [local("A", "Other", hash)])).toBeUndefined();
+  });
+
+  it("matches the filename case-insensitively", async () => {
+    const hash = await hashOf("deck");
+    const match = await matchReupload("TALK", hash, [local("A", "talk", hash)]);
+    expect(match).toEqual({ target: local("A", "talk", hash), identical: true, compared: true });
+  });
+
+  it("reports a byte-identical local re-drop as identical", async () => {
+    const hash = await hashOf("deck");
+    const match = await matchReupload("Talk", hash, [local("A", "Talk", hash)]);
+    expect(match?.identical).toBe(true);
+  });
+
+  it("reports a same-name local deck with different bytes as a non-identical match", async () => {
+    const match = await matchReupload("Talk", await hashOf("v2"), [
+      local("A", "Talk", await hashOf("v1")),
+    ]);
+    expect(match).toEqual({
+      target: expect.objectContaining({ id: "A" }),
+      identical: false,
+      compared: true,
+    });
+  });
+
+  it("backfills a missing fingerprint from the stored blob and remembers it", async () => {
+    seedRecord("A", "deck");
+    const hash = await hashOf("deck");
+    const match = await matchReupload("Talk", hash, [local("A", "Talk")]);
+    expect(match?.identical).toBe(true);
+    expect(idbGet).toHaveBeenCalledWith("A");
+    expect(records.get("A")?.sha256).toBe(hash);
+  });
+
+  it("skips a local row whose IndexedDB record is gone", async () => {
+    // Nothing seeded: the row is a leftover with nothing left to update.
+    expect(await matchReupload("Talk", await hashOf("deck"), [local("A", "Talk")])).toBeUndefined();
+  });
+
+  it("matches synced and account rows on name alone, never as identical", async () => {
+    const hash = await hashOf("deck");
+    expect(await matchReupload("Talk", hash, [synced("S", "Talk")])).toEqual({
+      target: synced("S", "Talk"),
+      identical: false,
+      compared: false,
+    });
+    expect(await matchReupload("Talk", hash, [account("Q", "Talk")])).toEqual({
+      target: account("Q", "Talk"),
+      identical: false,
+      compared: false,
+    });
+  });
+
+  it("matches a recompile that changed the slide count — count is not part of the match", async () => {
+    // The row carries no slide count at all: only the name (and, for local
+    // rows, the bytes) decide. A deck that gained a slide still matches.
+    const match = await matchReupload("Talk", await hashOf("v2"), [synced("S", "Talk")]);
+    expect(match?.target.id).toBe("S");
+  });
+
+  it("degrades to a name-only match when the file could not be hashed", async () => {
+    // No crypto.subtle (plain-http origin): never claims identical, but still
+    // offers the update rather than silently creating a second presentation.
+    const match = await matchReupload("Talk", undefined, [local("A", "Talk", "stored-hash")]);
+    expect(match).toEqual({
+      target: expect.objectContaining({ id: "A" }),
+      identical: false,
+      // Nothing was weighed, so the prompt must not claim the content differs.
+      compared: false,
+    });
+    expect(idbGet).not.toHaveBeenCalled();
+  });
+
+  it("prefers a local row over a synced one with the same name", async () => {
+    const match = await matchReupload("Talk", await hashOf("v2"), [
+      synced("S", "Talk"),
+      local("A", "Talk", await hashOf("v1")),
+    ]);
+    expect(match?.target.id).toBe("A");
+  });
+
+  it("prefers the byte-identical local row over an earlier same-name one", async () => {
+    const hash = await hashOf("deck");
+    const match = await matchReupload("Talk", hash, [
+      local("A", "Talk", await hashOf("other")),
+      local("B", "Talk", hash),
+    ]);
+    expect(match).toEqual({
+      target: expect.objectContaining({ id: "B" }),
+      identical: true,
+      compared: true,
+    });
+  });
+
+  it("doesn't claim the content differs when the stored copy couldn't be read", async () => {
+    idbGet.mockRejectedValueOnce(new Error("storage unavailable"));
+    const match = await matchReupload("Talk", await hashOf("v2"), [local("A", "Talk")]);
+    expect(match).toEqual({
+      target: expect.objectContaining({ id: "A" }),
+      identical: false,
+      compared: false,
+    });
+  });
+
+  it("falls back to the first local row when none is identical", async () => {
+    // idbList orders locals newest-first, so the first is the freshest copy.
+    const match = await matchReupload("Talk", await hashOf("v3"), [
+      local("NEW", "Talk", await hashOf("v2")),
+      local("OLD", "Talk", await hashOf("v1")),
+    ]);
+    expect(match?.target.id).toBe("NEW");
+  });
+});

--- a/client/src/lib/reupload.ts
+++ b/client/src/lib/reupload.ts
@@ -1,0 +1,99 @@
+// Recognising a dropped PDF as a re-upload of a presentation this browser
+// already knows about, so the home screen can offer to swap it in under the
+// existing code instead of minting a second presentation for the same deck.
+//
+// The whole comparison is local: the recents list is already in memory and the
+// stored fingerprints come from IndexedDB, so a drop that matches nothing costs
+// no network round-trip and adds no delay to the ordinary create path.
+
+import { idbGet, idbPut } from "@/lib/localStore";
+import { sha256Hex } from "@/lib/analytics";
+
+/** The part of a recents row this matcher needs. Home's `RecentDeck` satisfies
+ *  it; the generic below hands the caller its own row type back. */
+export interface ReuploadCandidate {
+  id: string;
+  filename: string;
+  kind: "local" | "synced" | "account";
+  /** Local rows only: SHA-256 of the stored PDF's bytes, when known. */
+  sha256?: string;
+}
+
+/**
+ * The fingerprint of a local row's stored PDF, backfilling it from the blob for
+ * records created before decks were fingerprinted (and remembering the result,
+ * so the next drop needs no blob read).
+ *
+ * `null` means the row's IndexedDB record is gone — there is nothing left to
+ * update, so the row isn't a re-upload target at all. `undefined` means the
+ * record is there but couldn't be hashed.
+ */
+async function storedHashOf(row: ReuploadCandidate): Promise<string | null | undefined> {
+  if (row.sha256) return row.sha256;
+  let rec;
+  try {
+    rec = await idbGet(row.id);
+  } catch {
+    return undefined; // storage unavailable: can't compare, but don't drop the row
+  }
+  if (!rec) return null;
+  try {
+    const hash = await sha256Hex(await rec.blob.arrayBuffer());
+    await idbPut({ ...rec, sha256: hash });
+    return hash;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Find the presentation a dropped PDF is most likely a re-upload of.
+ *
+ * Matching is by filename. Local rows additionally compare content hashes, so a
+ * byte-identical re-drop can be recognised outright (`identical: true`) — that's
+ * someone who lost their link rather than changed their deck, and it wants no
+ * prompt at all.
+ *
+ * `compared` says whether the bytes were actually weighed against a stored copy.
+ * Synced and account rows carry no local bytes, and a local row can be missing
+ * its record's hash, so the caller must not tell the presenter the content
+ * differs unless this is true.
+ *
+ * Slide count is deliberately *not* part of the match. A recompile that gained
+ * or lost a slide is both the commonest case and the one where keeping the
+ * existing code matters most, since the link is already out.
+ *
+ * Local rows are preferred over synced ones when a name is duplicated (only
+ * they can be compared by content), and `idbList` already orders them
+ * newest-first, so the freshest copy wins.
+ *
+ * A missing `fileHash` (no `crypto.subtle`, e.g. a plain-http origin) degrades
+ * every match to name-only rather than disabling the feature.
+ */
+export async function matchReupload<T extends ReuploadCandidate>(
+  filename: string,
+  fileHash: string | undefined,
+  recents: readonly T[]
+): Promise<{ target: T; identical: boolean; compared: boolean } | undefined> {
+  const name = filename.toLowerCase();
+  const named = recents.filter((r) => r.filename.toLowerCase() === name);
+  if (!named.length) return undefined;
+
+  const locals: { row: T; compared: boolean }[] = [];
+  for (const row of named) {
+    if (row.kind !== "local") continue;
+    if (!fileHash) {
+      locals.push({ row, compared: false });
+      continue;
+    }
+    const stored = await storedHashOf(row);
+    if (stored === null) continue; // record gone — nothing to update
+    if (stored === fileHash) return { target: row, identical: true, compared: true };
+    locals.push({ row, compared: stored !== undefined });
+  }
+
+  const best = locals[0];
+  if (best) return { target: best.row, identical: false, compared: best.compared };
+  const other = named.find((r) => r.kind !== "local");
+  return other ? { target: other, identical: false, compared: false } : undefined;
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -11,10 +11,11 @@ import { CodeBlock } from "@/components/CodeBlock";
 import { ConfirmReplaceDialog } from "@/components/controller/ConfirmReplaceDialog";
 import { ConfirmReuploadDialog } from "@/components/controller/ConfirmReuploadDialog";
 import { ConfirmEndDialog } from "@/components/controller/ConfirmEndDialog";
-import { idbPut, idbGet, idbList, idbDelete } from "@/lib/localStore";
+import { idbPut, idbList, idbDelete } from "@/lib/localStore";
 import { getSessionAuth, setSessionAuth, endSession } from "@/lib/utils";
 import { lsRemove, annotationsKey, sessionKey } from "@/lib/storage";
 import { track, sha256Hex } from "@/lib/analytics";
+import { matchReupload } from "@/lib/reupload";
 import { loadExternalPdfMeta, createExternalSession } from "@/lib/externalSession";
 import { supabase } from "@/lib/supabaseClient";
 import { useAuth } from "@/lib/useAuth";
@@ -254,12 +255,13 @@ interface RecentDeck {
 const SESSION_KEY_RE = /^session_([A-Z0-9]{6})$/;
 
 // A dropped file that matched a known presentation and is waiting on the
-// update-vs-create prompt. The already-decoded bytes are kept so "Create
-// separate" doesn't re-read or re-parse the file.
+// update-vs-create prompt. The decoded blob is kept so "Create separate"
+// doesn't re-read or re-parse the file. (The ArrayBuffer it came from is not:
+// getDocument() has already transferred it to the pdf.js worker by this point,
+// leaving it detached.)
 interface ReuploadPrompt {
   target: RecentDeck;
   file: File;
-  buf: ArrayBuffer;
   blob: Blob;
   sha256?: string;
   filename: string;
@@ -338,44 +340,6 @@ async function listAccountSynced(): Promise<RecentDeck[]> {
   }
 }
 
-// Find a recent presentation a dropped PDF could be a re-upload of, before
-// anything is created. The comparison is purely local — the recents list is
-// already in memory and no network round-trip happens. Local rows compare
-// content hashes (backfilling the stored hash from the blob on demand for
-// records created before fingerprinting existed); synced and account rows
-// carry no local bytes, so they match on filename and slide count alone and
-// never claim the content is identical. A missing crypto.subtle (plain-http
-// origins) degrades every match to name-only.
-async function matchReupload(
-  filename: string,
-  totalSlides: number,
-  fileHash: string | undefined,
-  recents: RecentDeck[]
-): Promise<{ target: RecentDeck; identical: boolean } | undefined> {
-  const target = recents.find(
-    (r) => r.filename.toLowerCase() === filename.toLowerCase()
-  );
-  if (!target) return undefined;
-  if (target.kind !== "local") {
-    return target.totalSlides === totalSlides
-      ? { target, identical: false }
-      : undefined;
-  }
-  if (!fileHash) return { target, identical: false };
-  let storedHash = target.sha256;
-  if (!storedHash) {
-    try {
-      const rec = await idbGet(target.id);
-      if (!rec) return undefined;
-      storedHash = await sha256Hex(await rec.blob.arrayBuffer());
-      // Remember the backfilled hash so the next drop needs no blob read.
-      await idbPut({ ...rec, sha256: storedHash });
-    } catch {
-      return { target, identical: false };
-    }
-  }
-  return { target, identical: storedHash === fileHash };
-}
 
 export default function Home() {
   const navigate = useNavigate();
@@ -620,7 +584,6 @@ export default function Home() {
   const createDeck = useCallback(
     async (p: {
       file: File;
-      buf: ArrayBuffer;
       blob: Blob;
       sha256?: string;
       filename: string;
@@ -696,7 +659,7 @@ export default function Home() {
         // Fork on a re-upload before anything is created: the recents list is
         // already in memory, so the comparison costs no network round-trip and
         // a no-match drop adds no prompt or delay.
-        const match = await matchReupload(filename, totalSlides, sha256, recents);
+        const match = await matchReupload(filename, sha256, recents);
         if (match?.identical) {
           // Byte-identical re-drop — the person most likely lost their link
           // rather than changed their deck. Reopen the existing presentation
@@ -711,16 +674,15 @@ export default function Home() {
           setReuploadPrompt({
             target: match.target,
             file,
-            buf,
             blob,
             sha256,
             filename,
             totalSlides,
-            compared: match.target.kind === "local" && !!sha256,
+            compared: match.compared,
           });
           return;
         }
-        await createDeck({ file, buf, blob, sha256, filename, totalSlides });
+        await createDeck({ file, blob, sha256, filename, totalSlides });
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : "Upload failed");
       } finally {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -9,8 +9,9 @@ import { PresioLogo } from "@/components/PresioLogo";
 import { MobileNotice } from "@/components/MobileNotice";
 import { CodeBlock } from "@/components/CodeBlock";
 import { ConfirmReplaceDialog } from "@/components/controller/ConfirmReplaceDialog";
+import { ConfirmReuploadDialog } from "@/components/controller/ConfirmReuploadDialog";
 import { ConfirmEndDialog } from "@/components/controller/ConfirmEndDialog";
-import { idbPut, idbList, idbDelete } from "@/lib/localStore";
+import { idbPut, idbGet, idbList, idbDelete } from "@/lib/localStore";
 import { getSessionAuth, setSessionAuth, endSession } from "@/lib/utils";
 import { lsRemove, annotationsKey, sessionKey } from "@/lib/storage";
 import { track, sha256Hex } from "@/lib/analytics";
@@ -242,12 +243,30 @@ interface RecentDeck {
   totalSlides: number;
   /** Present only for local decks (IndexedDB creation time). */
   createdAt: number | null;
+  /** Local decks only: SHA-256 of the stored PDF's bytes, when known — lets a
+   * re-drop be recognised as byte-identical without touching the blob. */
+  sha256?: string;
   kind: "local" | "synced" | "account";
   /** Account decks only: the controller token returned by /api/sessions/mine. */
   controllerToken?: string;
 }
 
 const SESSION_KEY_RE = /^session_([A-Z0-9]{6})$/;
+
+// A dropped file that matched a known presentation and is waiting on the
+// update-vs-create prompt. The already-decoded bytes are kept so "Create
+// separate" doesn't re-read or re-parse the file.
+interface ReuploadPrompt {
+  target: RecentDeck;
+  file: File;
+  buf: ArrayBuffer;
+  blob: Blob;
+  sha256?: string;
+  filename: string;
+  totalSlides: number;
+  /** Whether the file's bytes were actually compared (local decks only). */
+  compared: boolean;
+}
 
 async function listControlledSynced(): Promise<RecentDeck[]> {
   const ids: string[] = [];
@@ -319,6 +338,45 @@ async function listAccountSynced(): Promise<RecentDeck[]> {
   }
 }
 
+// Find a recent presentation a dropped PDF could be a re-upload of, before
+// anything is created. The comparison is purely local — the recents list is
+// already in memory and no network round-trip happens. Local rows compare
+// content hashes (backfilling the stored hash from the blob on demand for
+// records created before fingerprinting existed); synced and account rows
+// carry no local bytes, so they match on filename and slide count alone and
+// never claim the content is identical. A missing crypto.subtle (plain-http
+// origins) degrades every match to name-only.
+async function matchReupload(
+  filename: string,
+  totalSlides: number,
+  fileHash: string | undefined,
+  recents: RecentDeck[]
+): Promise<{ target: RecentDeck; identical: boolean } | undefined> {
+  const target = recents.find(
+    (r) => r.filename.toLowerCase() === filename.toLowerCase()
+  );
+  if (!target) return undefined;
+  if (target.kind !== "local") {
+    return target.totalSlides === totalSlides
+      ? { target, identical: false }
+      : undefined;
+  }
+  if (!fileHash) return { target, identical: false };
+  let storedHash = target.sha256;
+  if (!storedHash) {
+    try {
+      const rec = await idbGet(target.id);
+      if (!rec) return undefined;
+      storedHash = await sha256Hex(await rec.blob.arrayBuffer());
+      // Remember the backfilled hash so the next drop needs no blob read.
+      await idbPut({ ...rec, sha256: storedHash });
+    } catch {
+      return { target, identical: false };
+    }
+  }
+  return { target, identical: storedHash === fileHash };
+}
+
 export default function Home() {
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -343,6 +401,7 @@ export default function Home() {
   const [replaceTarget, setReplaceTarget] = useState<RecentDeck | null>(null);
   const [replaceFile, setReplaceFile] = useState<File | null>(null);
   const [replacing, setReplacing] = useState(false);
+  const [reuploadPrompt, setReuploadPrompt] = useState<ReuploadPrompt | null>(null);
   const [closeTarget, setCloseTarget] = useState<RecentDeck | null>(null);
   const [closing, setClosing] = useState(false);
 
@@ -356,6 +415,7 @@ export default function Home() {
             filename: r.filename,
             totalSlides: r.totalSlides,
             createdAt: r.createdAt,
+            sha256: r.sha256,
             kind: "local",
           }))
         )
@@ -450,27 +510,34 @@ export default function Home() {
     }
   }, [closeTarget, closing]);
 
-  const confirmReplace = useCallback(async () => {
-    if (!replaceTarget || !replaceFile || replacing) return;
-    setReplacing(true);
-    setError("");
-    try {
-      const buf = await replaceFile.arrayBuffer();
+  // Swap a deck's PDF in place under the same code — the body shared by the
+  // recents list' Replace button and the re-upload prompt's Update action.
+  const replaceDeck = useCallback(
+    async (target: RecentDeck, file: File) => {
+      const buf = await file.arrayBuffer();
       // Snapshot the bytes before getDocument() transfers the buffer to the
       // pdf.js worker and detaches it (same ordering as upload()).
       const blob = new Blob([buf], { type: "application/pdf" });
+      // Fingerprint the bytes while they're still readable (see upload()).
+      let sha256: string | undefined;
+      try {
+        sha256 = await sha256Hex(buf);
+      } catch {
+        // No crypto.subtle (plain-http origins): track without a fingerprint.
+      }
       const doc = await getDocument({ data: new Uint8Array(buf) }).promise;
       const totalSlides = doc.numPages;
       doc.destroy();
-      const filename = replaceFile.name.replace(/\.pdf$/i, "");
-      if (replaceTarget.kind === "local") {
+      const filename = file.name.replace(/\.pdf$/i, "");
+      if (target.kind === "local") {
         try {
           await idbPut({
-            id: replaceTarget.id,
+            id: target.id,
             filename,
             totalSlides,
             blob,
-            createdAt: replaceTarget.createdAt ?? Date.now(),
+            sha256,
+            createdAt: target.createdAt ?? Date.now(),
           });
         } catch {
           throw new Error(
@@ -483,13 +550,13 @@ export default function Home() {
         // never controlled, fall back to the token /api/sessions/mine returned.
         // A logged-in owner token is attached too when present (the server
         // accepts either).
-        const stored = getSessionAuth(replaceTarget.id);
-        const controllerToken = stored.controllerToken ?? replaceTarget.controllerToken;
+        const stored = getSessionAuth(target.id);
+        const controllerToken = stored.controllerToken ?? target.controllerToken;
         if (!controllerToken) {
           throw new Error("This browser isn't the controller for this presentation");
         }
         if (!stored.controllerToken) {
-          setSessionAuth(replaceTarget.id, { ...stored, controllerToken });
+          setSessionAuth(target.id, { ...stored, controllerToken });
         }
         const headers: Record<string, string> = { "x-controller-token": controllerToken };
         const { data: sessionData } = await supabase.auth.getSession();
@@ -499,7 +566,7 @@ export default function Home() {
         const form = new FormData();
         form.append("pdf", blob, `${filename}.pdf`);
         form.append("filename", filename);
-        const res = await fetch(`/api/sessions/${replaceTarget.id}/pdf`, {
+        const res = await fetch(`/api/sessions/${target.id}/pdf`, {
           method: "POST",
           headers,
           body: form,
@@ -510,33 +577,88 @@ export default function Home() {
         }
       }
       // Drawings are keyed by slide number; a replaced deck invalidates them.
-      lsRemove(annotationsKey(replaceTarget.id));
-      let sha256: string | undefined;
-      try {
-        sha256 = await sha256Hex(buf);
-      } catch {
-        // No crypto.subtle (plain-http origins): track without a fingerprint.
-      }
+      lsRemove(annotationsKey(target.id));
+      // Keep the in-memory recents row in step with the stored record — the
+      // hash must reflect the new bytes for the next re-drop to be matched.
+      setRecents((rs) =>
+        rs.map((r) => (r.id === target.id ? { ...r, filename, totalSlides, sha256 } : r))
+      );
       track("deck-replace", {
         filename,
         sha256,
-        size: replaceFile.size,
+        size: file.size,
         slides: totalSlides,
-        mode: replaceTarget.kind === "local" ? "local" : "server",
+        mode: target.kind === "local" ? "local" : "server",
       });
-      navigate(`/s/${replaceTarget.id}?role=controller`);
+      navigate(`/s/${target.id}?role=controller`);
+    },
+    [navigate]
+  );
+
+  const confirmReplace = useCallback(async () => {
+    if (!replaceTarget || !replaceFile || replacing) return;
+    setReplacing(true);
+    setError("");
+    try {
+      await replaceDeck(replaceTarget, replaceFile);
+      setReplaceTarget(null);
+      setReplaceFile(null);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to replace the PDF");
     } finally {
       setReplacing(false);
     }
-  }, [replaceTarget, replaceFile, replacing, navigate]);
+  }, [replaceTarget, replaceFile, replacing, replaceDeck]);
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 8);
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
+
+  // The plain create path: mint a session, store the deck locally, open share.
+  const createDeck = useCallback(
+    async (p: {
+      file: File;
+      buf: ArrayBuffer;
+      blob: Blob;
+      sha256?: string;
+      filename: string;
+      totalSlides: number;
+    }) => {
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      const { data: sessionData } = await supabase.auth.getSession();
+      if (sessionData.session) headers.Authorization = `Bearer ${sessionData.session.access_token}`;
+      const res = await fetch("/api/sessions/local", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ filename: p.filename, total_slides: p.totalSlides }),
+      });
+      if (!res.ok) throw new Error("Failed to create session");
+      const { id, controllerToken, passphrase } = await res.json();
+      if (controllerToken) setSessionAuth(id, { controllerToken, passphrase });
+      try {
+        await idbPut({
+          id,
+          filename: p.filename,
+          totalSlides: p.totalSlides,
+          blob: p.blob,
+          sha256: p.sha256,
+          createdAt: Date.now(),
+        });
+      } catch {
+        throw new Error(
+          "Couldn't store the presentation in this browser. Private/incognito mode isn't supported — please use a normal window."
+        );
+      }
+      // Counted only once the deck is durably stored; the analytics sink
+      // timestamps each event, so two uploads of the same filename can be
+      // compared by hash to spot recompiled vs. re-uploaded decks.
+      track("upload", { filename: p.filename, sha256: p.sha256, size: p.file.size, slides: p.totalSlides });
+      navigate(`/s/${id}/share`);
+    },
+    [navigate]
+  );
 
   const upload = useCallback(
     async (file: File) => {
@@ -570,37 +692,75 @@ export default function Home() {
         const totalSlides = doc.numPages;
         doc.destroy();
         const filename = file.name.replace(/\.pdf$/i, "");
-        const headers: Record<string, string> = { "Content-Type": "application/json" };
-        const { data: sessionData } = await supabase.auth.getSession();
-        if (sessionData.session) headers.Authorization = `Bearer ${sessionData.session.access_token}`;
-        const res = await fetch("/api/sessions/local", {
-          method: "POST",
-          headers,
-          body: JSON.stringify({ filename, total_slides: totalSlides }),
-        });
-        if (!res.ok) throw new Error("Failed to create session");
-        const { id, controllerToken, passphrase } = await res.json();
-        if (controllerToken) setSessionAuth(id, { controllerToken, passphrase });
-        try {
-          await idbPut({ id, filename, totalSlides, blob, createdAt: Date.now() });
-        } catch {
-          throw new Error(
-            "Couldn't store the presentation in this browser. Private/incognito mode isn't supported — please use a normal window."
-          );
+
+        // Fork on a re-upload before anything is created: the recents list is
+        // already in memory, so the comparison costs no network round-trip and
+        // a no-match drop adds no prompt or delay.
+        const match = await matchReupload(filename, totalSlides, sha256, recents);
+        if (match?.identical) {
+          // Byte-identical re-drop — the person most likely lost their link
+          // rather than changed their deck. Reopen the existing presentation
+          // and create nothing.
+          navigate(`/s/${match.target.id}?role=controller`);
+          return;
         }
-        // Counted only once the deck is durably stored; the analytics sink
-        // timestamps each event, so two uploads of the same filename can be
-        // compared by hash to spot recompiled vs. re-uploaded decks.
-        track("upload", { filename, sha256, size: file.size, slides: totalSlides });
-        navigate(`/s/${id}/share`);
+        if (match) {
+          // Same name, different (or unverifiable) bytes: offer update vs.
+          // create, defaulting to update, before anything exists server-side
+          // or in IndexedDB.
+          setReuploadPrompt({
+            target: match.target,
+            file,
+            buf,
+            blob,
+            sha256,
+            filename,
+            totalSlides,
+            compared: match.target.kind === "local" && !!sha256,
+          });
+          return;
+        }
+        await createDeck({ file, buf, blob, sha256, filename, totalSlides });
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : "Upload failed");
       } finally {
         setUploading(false);
       }
     },
-    [navigate]
+    [navigate, recents, createDeck]
   );
+
+  // Update branch of the re-upload prompt: swap the dropped file into the
+  // matched presentation via the same code path as the recents Replace button.
+  const confirmReuploadUpdate = useCallback(async () => {
+    if (!reuploadPrompt || replacing) return;
+    setReplacing(true);
+    setError("");
+    try {
+      await replaceDeck(reuploadPrompt.target, reuploadPrompt.file);
+      setReuploadPrompt(null);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to replace the PDF");
+    } finally {
+      setReplacing(false);
+    }
+  }, [reuploadPrompt, replacing, replaceDeck]);
+
+  // Create branch of the re-upload prompt: continue down the plain create
+  // path, reusing the already-decoded bytes.
+  const confirmReuploadCreate = useCallback(async () => {
+    if (!reuploadPrompt || uploading) return;
+    setUploading(true);
+    setError("");
+    try {
+      await createDeck(reuploadPrompt);
+      setReuploadPrompt(null);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  }, [reuploadPrompt, uploading, createDeck]);
 
   const submitUrl = useCallback(
     async (e: React.FormEvent) => {
@@ -1120,6 +1280,17 @@ Hello world.
         <ConfirmReplaceDialog
           onConfirm={confirmReplace}
           onClose={() => { setReplaceTarget(null); setReplaceFile(null); }}
+        />
+      )}
+
+      {reuploadPrompt && (
+        <ConfirmReuploadDialog
+          filename={reuploadPrompt.filename}
+          code={reuploadPrompt.target.id}
+          compared={reuploadPrompt.compared}
+          onUpdate={confirmReuploadUpdate}
+          onCreate={confirmReuploadCreate}
+          onClose={() => setReuploadPrompt(null)}
         />
       )}
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -554,7 +554,11 @@ export default function Home() {
         slides: totalSlides,
         mode: target.kind === "local" ? "local" : "server",
       });
-      navigate(`/s/${target.id}?role=controller`);
+      // A synced replace rewrites the stored object at the same URL, so tell
+      // the controller page to fetch past any copy this browser already has —
+      // it's the one most likely to be holding the pre-replace deck. Viewers
+      // in the room get there by their own route (the deck_updated broadcast).
+      navigate(`/s/${target.id}?role=controller`, { state: { deckReplaced: Date.now() } });
     },
     [navigate]
   );

--- a/client/src/pages/Presentation.tsx
+++ b/client/src/pages/Presentation.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from "react";
-import { useParams, useSearchParams, useNavigate, Link } from "react-router-dom";
+import { useParams, useSearchParams, useNavigate, useLocation, Link } from "react-router-dom";
 import type { PDFDocumentProxy } from "pdfjs-dist";
 import { getDocument } from "pdfjs-dist";
-import { loadPdf, loadPdfData, renderPage, clearCache } from "@/lib/pdf";
+import { loadPdf, loadPdfData, freshPdfUrl, renderPage, clearCache } from "@/lib/pdf";
 import { loadDeckInfo, type Deck, type DeckInfo } from "@/lib/deck";
 import { setSlideNotes } from "@/lib/notesAttach";
 import { defaultAudioState, isMutedForRole, type MediaState, type MediaTimeSync, type AudioState } from "@/lib/media";
@@ -24,6 +24,10 @@ export default function Presentation() {
   const { id } = useParams<{ id: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  // Set by Home when it navigates here right after replacing this deck's PDF
+  // (see the initial load below). A timestamp, not a flag, so the cache-busted
+  // URL is stable across reloads of this page.
+  const replacedAt = (useLocation().state as { deckReplaced?: number } | null)?.deckReplaced;
   const requestedRole = searchParams.get("role") || "viewer";
   const [role, setRole] = useState(requestedRole);
   // The role once the session actually settles it — null while the request is
@@ -159,9 +163,7 @@ export default function Presentation() {
             // The stored object path doesn't change on replace, so bust any
             // cached copy along the way before re-fetching.
             clearCache();
-            const base = pdfUrlRef.current;
-            const busted = `${base}${base.includes("?") ? "&" : "?"}v=${Date.now()}`;
-            const doc = await loadPdf(busted);
+            const doc = await loadPdf(freshPdfUrl(pdfUrlRef.current, Date.now()));
             setPdf(doc);
           }
         } catch {
@@ -206,8 +208,18 @@ export default function Presentation() {
         }
         if (cancelled) return;
         setLocal(false);
-        const doc = await loadPdf(session.pdfUrl);
+        // Arriving straight from a replace (Home's recents/re-upload flow) the
+        // stored object has new bytes at the same URL, and this browser is the
+        // one most likely to have the old copy cached — it had the deck open
+        // before. Viewers already in the room don't hit this: they get
+        // deck_updated and reload through applyDeckUpdate, which busts too.
+        // Keyed by the replace's own timestamp, so a reload of this page reuses
+        // the fetch rather than starting another one.
+        const doc = await loadPdf(
+          replacedAt ? freshPdfUrl(session.pdfUrl, replacedAt) : session.pdfUrl
+        );
         if (cancelled) return;
+        // Store the canonical URL: later reloads append their own version.
         setPdfUrl(session.pdfUrl);
         setPdf(doc);
         setFilename(session.filename);
@@ -224,7 +236,10 @@ export default function Presentation() {
       clearCache();
       if (localUrlRef.current) URL.revokeObjectURL(localUrlRef.current);
     };
-  }, [id]);
+    // replacedAt belongs here: replacing the same deck again from Home routes
+    // back to this already-mounted page with a new timestamp, and that has to
+    // reload the document rather than leave the previous one on screen.
+  }, [id, replacedAt]);
 
   // The loaded document decides the page count: URL-backed decks re-fetch
   // their PDF on every load, so a republished file can change the page count

--- a/client/src/pages/Presentation.tsx
+++ b/client/src/pages/Presentation.tsx
@@ -698,7 +698,7 @@ export default function Presentation() {
       if (local) {
         const rec = await idbGet(id!);
         if (!rec) throw new Error("This presentation is no longer in this browser");
-        await idbPut({ ...rec, blob, filename, totalSlides });
+        await idbPut({ ...rec, blob, filename, totalSlides, sha256 });
         channelRef.current?.postMessage({
           type: "deck_update",
           payload: { filename, totalSlides },


### PR DESCRIPTION
Closes #19. Stacked on #70 (`feat/issue-15-synced-decks`) — retargets to `main` when that merges.

## What
- `sha256?: string` persisted on `LocalPresentation` (`DB_VERSION` 1→2, old records just lack the hash); hashed on create/replace and lazily backfilled from the stored blob on a filename match.
- On drop/browse in Home, before anything is created, the file is matched against recents (purely local, no network):
  - **byte-identical** → reopens the existing presentation, creating nothing (lost-my-link case)
  - **filename match, different bytes** → new `ConfirmReuploadDialog`: *Update "name", keep code* (default) / *Create separate*
  - **no match** → today's create path, no prompt, no delay
- `confirmReplace`'s body factored into a shared `replaceDeck(target, file)` helper used by both the recents **Replace** button and the new prompt. The controller's explicit **Replace PDF…** gains no prompt. Hash is computed before `getDocument()` detaches the buffer; missing `crypto.subtle` (plain http) degrades to filename-only matching.

## Decisions / assumptions
- A byte-identical re-drop reopens immediately instead of showing a "you already have this deck" dialog — same outcome, no extra friction.
- Synced/account rows match on filename + slide count only and never claim "identical" in the prompt (no local bytes to compare).
- Hash persistence is scoped to Home's create/replace paths (Start/Checker create flows don't compute a hash today).

## Verification
Client: `tsc -b`, `eslint`, vitest 30/30.