### PR TITLE
Refresh URL-backed decks mid-session when the remote PDF is republished (#20)

### DIFF
--- a/client/src/components/CodeBlock.tsx
+++ b/client/src/components/CodeBlock.tsx
@@ -41,7 +41,7 @@ export function CodeBlock({ code, lang = "typst" }: CodeBlockProps) {
 
   return (
     <div
-      className="text-xs rounded-md overflow-x-auto border border-border dark:border-transparent [&_pre]:p-3 [&_pre]:rounded-md [&_pre]:overflow-x-auto"
+      className="text-xs rounded-md overflow-x-auto border border-border [&_pre]:p-3 [&_pre]:rounded-md [&_pre]:overflow-x-auto"
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/client/src/components/controller/ConfirmDeckReloadDialog.tsx
+++ b/client/src/components/controller/ConfirmDeckReloadDialog.tsx
@@ -7,6 +7,7 @@ import { DialogOverlay } from "@/components/ui/dialog-overlay";
 // Only ever shown in "prompt" mode; "auto" applies without asking.
 export function ConfirmDeckReloadDialog({
   filename,
+  source,
   annotatedSlides,
   notesEdited,
   busy,
@@ -14,6 +15,8 @@ export function ConfirmDeckReloadDialog({
   onClose,
 }: {
   filename: string;
+  /** Where the change came from: the file on disk, or the deck's source URL. */
+  source: "watch" | "remote";
   /** How many slides carry drawings right now (0 = nothing to lose). */
   annotatedSlides: number;
   /** Whether speaker notes were edited in Presio since this deck was loaded. */
@@ -33,10 +36,15 @@ export function ConfirmDeckReloadDialog({
   return (
     <DialogOverlay onClose={onClose}>
       <div className="space-y-2 text-center">
-        <h2 className="text-lg font-semibold">Deck updated on disk</h2>
+        <h2 className="text-lg font-semibold">
+          {source === "watch" ? "Deck updated on disk" : "New version published"}
+        </h2>
         <p className="text-sm text-muted-foreground">
-          <span className="font-medium text-foreground">{filename || "This deck"}</span> was
-          recompiled. Showing it swaps the slides for you and everyone watching.
+          <span className="font-medium text-foreground">{filename || "This deck"}</span>{" "}
+          {source === "watch"
+            ? "was recompiled."
+            : "changed at its source link."}{" "}
+          Showing it swaps the slides for you and everyone watching.
         </p>
         {losses.length > 0 && (
           <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">

--- a/client/src/components/controller/ControllerHeader.tsx
+++ b/client/src/components/controller/ControllerHeader.tsx
@@ -19,6 +19,7 @@ export function ControllerHeader({
   deckWatchMode = null,
   deckWatchStatus,
   onReplaceDeck,
+  onDropDeck,
   onDeckWatchCycle,
   onDeckWatchApply,
   onDeckWatchResume,
@@ -40,6 +41,8 @@ export function ControllerHeader({
   /** Deck file watching status (lib/deckWatcher). */
   deckWatchStatus?: DeckWatchStatus | null;
   onReplaceDeck?: () => void;
+  /** A PDF dropped onto the deck name — same swap, without the picker. */
+  onDropDeck?: (file: File, handle?: FileSystemFileHandle) => void;
   onDeckWatchCycle?: () => void;
   onDeckWatchApply?: () => void;
   onDeckWatchResume?: () => void;
@@ -50,8 +53,28 @@ export function ControllerHeader({
   compact?: boolean;
   actions?: ReactNode;
 }) {
+  const deck = onReplaceDeck && onDeckWatchCycle && onDeckWatchApply && onDeckWatchResume && (
+    <DeckControl
+      filename={filename}
+      mode={deckWatchMode}
+      status={deckWatchStatus ?? null}
+      remoteUpdate={remoteDeckUpdate}
+      onReplace={onReplaceDeck}
+      onDropDeck={onDropDeck}
+      onCycleMode={onDeckWatchCycle}
+      onApply={onDeckWatchApply}
+      onResume={onDeckWatchResume}
+      onRemoteApply={onRemoteDeckApply}
+    />
+  );
+
   return (
-    <div className={cn("border-b py-2 flex items-center justify-between", compact ? "px-3" : "px-4")}>
+    <div
+      className={cn(
+        "relative border-b py-2 flex items-center justify-between",
+        compact ? "px-3" : "px-4"
+      )}
+    >
       <div className={cn("flex items-center", compact ? "gap-2" : "gap-3")}>
         <Link
           to="/"
@@ -84,20 +107,19 @@ export function ControllerHeader({
             Code shown
           </span>
         )}
-        {onReplaceDeck && onDeckWatchCycle && onDeckWatchApply && onDeckWatchResume && (
-          <DeckControl
-            filename={filename}
-            mode={deckWatchMode}
-            status={deckWatchStatus ?? null}
-            remoteUpdate={remoteDeckUpdate}
-            onReplace={onReplaceDeck}
-            onCycleMode={onDeckWatchCycle}
-            onApply={onDeckWatchApply}
-            onResume={onDeckWatchResume}
-            onRemoteApply={onRemoteDeckApply}
-          />
-        )}
+        {compact && deck}
       </div>
+      {/* Desktop centres the deck on the bar itself rather than in the gap
+          between its neighbours, so it doesn't drift as the code or the
+          badges change width. Out of flow, so the wrapper can't swallow
+          clicks meant for the clusters underneath — only the control itself
+          takes pointer events. Mobile has no room for a third column, so it
+          stays inline in the left cluster above. */}
+      {!compact && deck && (
+        <div className="pointer-events-none absolute left-1/2 -translate-x-1/2">
+          <div className="pointer-events-auto">{deck}</div>
+        </div>
+      )}
       <div className="flex items-center gap-1">{actions}</div>
     </div>
   );

--- a/client/src/components/controller/ControllerHeader.tsx
+++ b/client/src/components/controller/ControllerHeader.tsx
@@ -20,7 +20,7 @@ export function ControllerHeader({
   deckWatchStatus,
   onReplaceDeck,
   onDropDeck,
-  onDeckWatchCycle,
+  onDeckWatchModeChange,
   onDeckWatchApply,
   onDeckWatchResume,
   remoteDeckUpdate = false,
@@ -43,7 +43,7 @@ export function ControllerHeader({
   onReplaceDeck?: () => void;
   /** A PDF dropped onto the deck name — same swap, without the picker. */
   onDropDeck?: (file: File, handle?: FileSystemFileHandle) => void;
-  onDeckWatchCycle?: () => void;
+  onDeckWatchModeChange?: (mode: DeckWatchMode) => void;
   onDeckWatchApply?: () => void;
   onDeckWatchResume?: () => void;
   /** A URL-backed deck's source PDF was republished — offer the new version. */
@@ -53,7 +53,7 @@ export function ControllerHeader({
   compact?: boolean;
   actions?: ReactNode;
 }) {
-  const deck = onReplaceDeck && onDeckWatchCycle && onDeckWatchApply && onDeckWatchResume && (
+  const deck = onReplaceDeck && onDeckWatchModeChange && onDeckWatchApply && onDeckWatchResume && (
     <DeckControl
       filename={filename}
       mode={deckWatchMode}
@@ -61,7 +61,7 @@ export function ControllerHeader({
       remoteUpdate={remoteDeckUpdate}
       onReplace={onReplaceDeck}
       onDropDeck={onDropDeck}
-      onCycleMode={onDeckWatchCycle}
+      onSetMode={onDeckWatchModeChange}
       onApply={onDeckWatchApply}
       onResume={onDeckWatchResume}
       onRemoteApply={onRemoteDeckApply}

--- a/client/src/components/controller/ControllerHeader.tsx
+++ b/client/src/components/controller/ControllerHeader.tsx
@@ -22,6 +22,8 @@ export function ControllerHeader({
   onDeckWatchCycle,
   onDeckWatchApply,
   onDeckWatchResume,
+  remoteDeckUpdate = false,
+  onRemoteDeckApply,
   actions,
 }: {
   id: string;
@@ -41,6 +43,9 @@ export function ControllerHeader({
   onDeckWatchCycle?: () => void;
   onDeckWatchApply?: () => void;
   onDeckWatchResume?: () => void;
+  /** A URL-backed deck's source PDF was republished — offer the new version. */
+  remoteDeckUpdate?: boolean;
+  onRemoteDeckApply?: () => void;
   /** Tighter spacing + bare code (no "Code:" label) for the mobile header. */
   compact?: boolean;
   actions?: ReactNode;
@@ -84,10 +89,12 @@ export function ControllerHeader({
             filename={filename}
             mode={deckWatchMode}
             status={deckWatchStatus ?? null}
+            remoteUpdate={remoteDeckUpdate}
             onReplace={onReplaceDeck}
             onCycleMode={onDeckWatchCycle}
             onApply={onDeckWatchApply}
             onResume={onDeckWatchResume}
+            onRemoteApply={onRemoteDeckApply}
           />
         )}
       </div>

--- a/client/src/components/controller/DeckControl.tsx
+++ b/client/src/components/controller/DeckControl.tsx
@@ -14,7 +14,16 @@ import type { DeckWatchMode, DeckWatchStatus } from "@/lib/deckWatcher";
 const chipBase =
   "text-xs font-medium px-1.5 py-0.5 rounded transition-colors whitespace-nowrap";
 
-function modeChip(mode: DeckWatchMode, status: DeckWatchStatus | null) {
+interface Chip {
+  label: string;
+  title: string;
+  className: string;
+  /** What clicking does — "none" renders plain text instead of a button. */
+  action: "none" | "resume" | "apply" | "remote" | "cycle";
+  icon?: boolean;
+}
+
+function modeChip(mode: DeckWatchMode, status: DeckWatchStatus | null): Chip {
   // Trouble states outrank the mode: there is no point saying "watching" when
   // the grant lapsed or the file went away.
   if (status === "needs-permission") {
@@ -22,7 +31,7 @@ function modeChip(mode: DeckWatchMode, status: DeckWatchStatus | null) {
       label: "Resume watching",
       title: "Access to the deck file lapsed — click to resume watching it for recompiles",
       className: "text-amber-600 dark:text-amber-500 bg-amber-500/10 hover:bg-amber-500/20",
-      action: "resume" as const,
+      action: "resume",
     };
   }
   if (status === "stopped") {
@@ -30,7 +39,7 @@ function modeChip(mode: DeckWatchMode, status: DeckWatchStatus | null) {
       label: "Watch stopped",
       title: "The deck file was moved or deleted — watching stopped",
       className: "text-muted-foreground bg-muted",
-      action: "none" as const,
+      action: "none",
     };
   }
   if (status === "updated") {
@@ -38,7 +47,7 @@ function modeChip(mode: DeckWatchMode, status: DeckWatchStatus | null) {
       label: "Deck updated",
       title: "A recompiled version of this deck is ready — click to show it to everyone",
       className: "text-primary bg-primary/10 hover:bg-primary/20",
-      action: "apply" as const,
+      action: "apply",
     };
   }
   if (mode === "off") {
@@ -46,7 +55,7 @@ function modeChip(mode: DeckWatchMode, status: DeckWatchStatus | null) {
       label: "Live reload off",
       title: "Not watching the deck file — click to watch it for recompiles",
       className: "text-muted-foreground bg-muted hover:bg-muted-foreground/20",
-      action: "cycle" as const,
+      action: "cycle",
     };
   }
   if (mode === "auto") {
@@ -54,7 +63,7 @@ function modeChip(mode: DeckWatchMode, status: DeckWatchStatus | null) {
       label: "Auto reload",
       title: "Recompiles are applied as soon as they land — click to turn live reload off",
       className: "text-emerald-600 dark:text-emerald-500 bg-emerald-500/10 hover:bg-emerald-500/20",
-      action: "cycle" as const,
+      action: "cycle",
       icon: true,
     };
   }
@@ -71,22 +80,38 @@ export function DeckControl({
   filename,
   mode,
   status,
+  remoteUpdate = false,
   onReplace,
   onCycleMode,
   onResume,
   onApply,
+  onRemoteApply,
 }: {
   filename: string;
   /** null when this deck can't be watched (synced deck, or no File System
    *  Access API) — the filename still shows and still swaps the deck. */
   mode: DeckWatchMode | null;
   status: DeckWatchStatus | null;
+  /** A URL-backed deck's source PDF was republished. Reported by the server-side
+   *  poller rather than the file watcher, but it means the same thing to the
+   *  presenter, so it reads as the same chip. */
+  remoteUpdate?: boolean;
   onReplace: () => void;
   onCycleMode: () => void;
   onResume: () => void;
   onApply: () => void;
+  onRemoteApply?: () => void;
 }) {
-  const chip = mode ? modeChip(mode, status) : null;
+  const chip: Chip | null = remoteUpdate
+    ? {
+        label: "Deck updated",
+        title: "A newer version of this deck was published at its source URL — click to show it to everyone",
+        className: "text-primary bg-primary/10 hover:bg-primary/20",
+        action: "remote",
+      }
+    : mode
+      ? modeChip(mode, status)
+      : null;
   return (
     <span className="flex min-w-0 items-center gap-1.5">
       <button
@@ -112,7 +137,9 @@ export function DeckControl({
                 ? onResume
                 : chip.action === "apply"
                   ? onApply
-                  : onCycleMode
+                  : chip.action === "remote"
+                    ? onRemoteApply
+                    : onCycleMode
             }
             className={`${chipBase} ${chip.className} inline-flex items-center gap-1`}
           >

--- a/client/src/components/controller/DeckControl.tsx
+++ b/client/src/components/controller/DeckControl.tsx
@@ -1,81 +1,101 @@
-import { useCallback, useState, type DragEvent } from "react";
-import { FileText, Zap } from "lucide-react";
+import { useCallback, useState, type DragEvent, type ReactNode } from "react";
+import { ChevronDown, FileText, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { ButtonGroup } from "@/components/ui/button-group";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { DeckWatchMode, DeckWatchStatus } from "@/lib/deckWatcher";
 
 // The controller header's deck cluster: what is being presented, and — where
 // the browser can watch a file on disk — what happens when it changes.
 //
-// Two controls, because they're two different questions:
+// One button group, three jobs:
 //   • the filename swaps the deck by hand (click to pick a new PDF, or drop
 //     one straight onto it)
-//   • the chip beside it is live reload: off -> watching -> auto -> off
+//   • a light beside it reports live reload at a glance: pulsing green while
+//     watching, a bolt on auto, grey when off. Clicking it picks the mode.
+//   • a recompile that is ready to show is the one thing that can't wait in a
+//     menu, so it appears as its own button and applies on click.
 //
-// Everything here is local-deck only; a synced deck has no file on this
-// machine to watch, and passing `mode: null` renders just the filename.
+// Watching is local-deck only; a synced deck has no file on this machine to
+// watch, and passing `mode: null` renders just the filename.
 
-const chipBase =
-  "text-xs font-medium px-1.5 py-0.5 rounded transition-colors whitespace-nowrap";
+const MODES: { value: DeckWatchMode; label: string; hint: string }[] = [
+  { value: "off", label: "Off", hint: "Ignore changes to the file" },
+  { value: "prompt", label: "Watch and ask", hint: "Offer each recompile before it goes up" },
+  { value: "auto", label: "Auto reload", hint: "Show recompiles as soon as they land" },
+];
 
-interface Chip {
-  label: string;
-  title: string;
-  className: string;
-  /** What clicking does — "none" renders plain text instead of a button. */
-  action: "none" | "resume" | "apply" | "remote" | "cycle";
-  icon?: boolean;
+type Tone = "green" | "amber" | "muted";
+
+const dotTone: Record<Tone, string> = {
+  green: "bg-emerald-500",
+  amber: "bg-amber-500",
+  muted: "bg-muted-foreground/60",
+};
+
+// A pulse means "this is live right now" — reserved for watching, so a glance
+// at a still dot is enough to know nothing is being watched.
+function WatchDot({ tone, pulse = false }: { tone: Tone; pulse?: boolean }) {
+  return (
+    <span className="relative flex size-2 shrink-0">
+      {pulse && (
+        <span
+          className={cn(
+            "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
+            dotTone[tone]
+          )}
+        />
+      )}
+      <span className={cn("relative inline-flex size-2 rounded-full", dotTone[tone])} />
+    </span>
+  );
 }
 
-function modeChip(mode: DeckWatchMode, status: DeckWatchStatus | null): Chip {
-  // Trouble states outrank the mode: there is no point saying "watching" when
-  // the grant lapsed or the file went away.
+// What the light says. Trouble outranks the mode: there is no point showing a
+// healthy green pulse when the grant lapsed or the file went away.
+function watchLight(
+  mode: DeckWatchMode,
+  status: DeckWatchStatus | null
+): { icon: ReactNode; title: string; note?: string } {
   if (status === "needs-permission") {
     return {
-      label: "Resume watching",
-      title: "Access to the deck file lapsed — click to resume watching it for recompiles",
-      className: "text-amber-600 dark:text-amber-500 bg-amber-500/10 hover:bg-amber-500/20",
-      action: "resume",
+      icon: <WatchDot tone="amber" />,
+      title: "Access to the deck file lapsed — resume watching it for recompiles",
+      note: "Access to this file lapsed.",
     };
   }
   if (status === "stopped") {
     return {
-      label: "Watch stopped",
+      icon: <WatchDot tone="muted" />,
       title: "The deck file was moved or deleted — watching stopped",
-      className: "text-muted-foreground bg-muted",
-      action: "none",
-    };
-  }
-  if (status === "updated") {
-    return {
-      label: "Deck updated",
-      title: "A recompiled version of this deck is ready — click to show it to everyone",
-      className: "text-primary bg-primary/10 hover:bg-primary/20",
-      action: "apply",
-    };
-  }
-  if (mode === "off") {
-    return {
-      label: "Live reload off",
-      title: "Not watching the deck file — click to watch it for recompiles",
-      className: "text-muted-foreground bg-muted hover:bg-muted-foreground/20",
-      action: "cycle",
+      note: "The file was moved or deleted.",
     };
   }
   if (mode === "auto") {
     return {
-      label: "Auto reload",
-      title: "Recompiles are applied as soon as they land — click to turn live reload off",
-      className: "text-emerald-600 dark:text-emerald-500 bg-emerald-500/10 hover:bg-emerald-500/20",
-      action: "cycle",
-      icon: true,
+      icon: <Zap size={12} className="text-emerald-600 dark:text-emerald-500" />,
+      title: "Auto reload: recompiles are applied as soon as they land",
+    };
+  }
+  if (mode === "prompt") {
+    return {
+      icon: <WatchDot tone="green" pulse />,
+      title: "Watching this deck's file for recompiles, and asking before swapping",
     };
   }
   return {
-    label: "Watching",
-    title:
-      "Watching this deck's file for recompiles, and asking before swapping — click to apply them automatically",
-    className: "text-emerald-600 dark:text-emerald-500 hover:bg-emerald-500/10",
-    action: "cycle" as const,
+    icon: <WatchDot tone="muted" />,
+    title: "Not watching the deck file for recompiles",
   };
 }
 
@@ -86,7 +106,7 @@ export function DeckControl({
   remoteUpdate = false,
   onReplace,
   onDropDeck,
-  onCycleMode,
+  onSetMode,
   onResume,
   onApply,
   onRemoteApply,
@@ -98,13 +118,13 @@ export function DeckControl({
   status: DeckWatchStatus | null;
   /** A URL-backed deck's source PDF was republished. Reported by the server-side
    *  poller rather than the file watcher, but it means the same thing to the
-   *  presenter, so it reads as the same chip. */
+   *  presenter, so it reads as the same button. */
   remoteUpdate?: boolean;
   onReplace: () => void;
   /** A PDF was dropped on the filename. The handle rides along where the
    *  platform offers one, so a dropped deck stays watchable. */
   onDropDeck?: (file: File, handle?: FileSystemFileHandle) => void;
-  onCycleMode: () => void;
+  onSetMode: (mode: DeckWatchMode) => void;
   onResume: () => void;
   onApply: () => void;
   onRemoteApply?: () => void;
@@ -149,18 +169,14 @@ export function DeckControl({
   // it back, because ".pdf" is what makes this read as the file on disk.
   const label = filename ? (/\.pdf$/i.test(filename) ? filename : `${filename}.pdf`) : "Untitled deck";
 
-  const chip: Chip | null = remoteUpdate
-    ? {
-        label: "Deck updated",
-        title: "A newer version of this deck was published at its source URL — click to show it to everyone",
-        className: "text-primary bg-primary/10 hover:bg-primary/20",
-        action: "remote",
-      }
-    : mode
-      ? modeChip(mode, status)
-      : null;
+  // A watched recompile and a republished URL are different sources with the
+  // same answer for the presenter, so they share one button.
+  const pending = remoteUpdate || status === "updated";
+  const applyPending = remoteUpdate ? onRemoteApply : onApply;
+  const light = mode ? watchLight(mode, status) : null;
+
   return (
-    <span className="flex min-w-0 items-center gap-1.5">
+    <ButtonGroup className="min-w-0">
       <button
         type="button"
         onClick={onReplace}
@@ -181,30 +197,64 @@ export function DeckControl({
         <FileText size={12} className="shrink-0" />
         <span className="truncate">{label}</span>
       </button>
-      {chip &&
-        (chip.action === "none" ? (
-          <span title={chip.title} className={`${chipBase} ${chip.className}`}>
-            {chip.label}
-          </span>
-        ) : (
-          <button
-            type="button"
-            title={chip.title}
-            onClick={
-              chip.action === "resume"
-                ? onResume
-                : chip.action === "apply"
-                  ? onApply
-                  : chip.action === "remote"
-                    ? onRemoteApply
-                    : onCycleMode
-            }
-            className={`${chipBase} ${chip.className} inline-flex items-center gap-1`}
-          >
-            {chip.icon && <Zap size={11} />}
-            {chip.label}
-          </button>
-        ))}
-    </span>
+
+      {pending && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={applyPending}
+          title={
+            remoteUpdate
+              ? "A newer version of this deck was published at its source URL — click to show it to everyone"
+              : "A recompiled version of this deck is ready — click to show it to everyone"
+          }
+          className="h-8 border-primary/30 bg-primary/10 text-xs font-medium text-primary hover:bg-primary/20 hover:text-primary"
+        >
+          Deck updated
+        </Button>
+      )}
+
+      {light && mode && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              title={`${light.title} — click to change`}
+              className="h-8 gap-1 px-2 text-muted-foreground hover:text-foreground"
+            >
+              {light.icon}
+              <ChevronDown size={12} className="opacity-60" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-60">
+            <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+              {light.note ?? "Live reload"}
+            </DropdownMenuLabel>
+            {status === "needs-permission" && (
+              <>
+                <DropdownMenuItem onSelect={onResume}>Resume watching</DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            )}
+            <DropdownMenuRadioGroup
+              value={mode}
+              onValueChange={(value) => onSetMode(value as DeckWatchMode)}
+            >
+              {MODES.map((m) => (
+                <DropdownMenuRadioItem key={m.value} value={m.value} className="items-start">
+                  <span className="flex flex-col gap-0.5">
+                    <span>{m.label}</span>
+                    <span className="text-xs text-muted-foreground">{m.hint}</span>
+                  </span>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </ButtonGroup>
   );
 }

--- a/client/src/components/controller/DeckControl.tsx
+++ b/client/src/components/controller/DeckControl.tsx
@@ -1,11 +1,14 @@
+import { useCallback, useState, type DragEvent } from "react";
 import { FileText, Zap } from "lucide-react";
+import { cn } from "@/lib/utils";
 import type { DeckWatchMode, DeckWatchStatus } from "@/lib/deckWatcher";
 
 // The controller header's deck cluster: what is being presented, and — where
 // the browser can watch a file on disk — what happens when it changes.
 //
 // Two controls, because they're two different questions:
-//   • the filename swaps the deck by hand (click to pick a new PDF)
+//   • the filename swaps the deck by hand (click to pick a new PDF, or drop
+//     one straight onto it)
 //   • the chip beside it is live reload: off -> watching -> auto -> off
 //
 // Everything here is local-deck only; a synced deck has no file on this
@@ -82,6 +85,7 @@ export function DeckControl({
   status,
   remoteUpdate = false,
   onReplace,
+  onDropDeck,
   onCycleMode,
   onResume,
   onApply,
@@ -97,11 +101,54 @@ export function DeckControl({
    *  presenter, so it reads as the same chip. */
   remoteUpdate?: boolean;
   onReplace: () => void;
+  /** A PDF was dropped on the filename. The handle rides along where the
+   *  platform offers one, so a dropped deck stays watchable. */
+  onDropDeck?: (file: File, handle?: FileSystemFileHandle) => void;
   onCycleMode: () => void;
   onResume: () => void;
   onApply: () => void;
   onRemoteApply?: () => void;
 }) {
+  // Dragging a recompiled PDF onto the deck name is the same swap as clicking
+  // it, minus the picker. Only armed when a drop handler is wired.
+  const [dragging, setDragging] = useState(false);
+  const onDragOver = useCallback(
+    (e: DragEvent<HTMLButtonElement>) => {
+      if (!onDropDeck) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "copy";
+      setDragging(true);
+    },
+    [onDropDeck]
+  );
+  const onDrop = useCallback(
+    (e: DragEvent<HTMLButtonElement>) => {
+      if (!onDropDeck) return;
+      e.preventDefault();
+      setDragging(false);
+      const file = e.dataTransfer.files[0];
+      if (file?.type !== "application/pdf") return;
+      // Grab the File System Access handle synchronously, before the event is
+      // recycled, so a dropped deck stays watchable. Only trusted for a
+      // single-item drop: with several, items[0] may not be this file.
+      const items = e.dataTransfer.items;
+      const item = items.length === 1 ? items[0] : undefined;
+      const getHandle = item?.getAsFileSystemHandle?.bind(item);
+      if (getHandle) {
+        getHandle()
+          .then((h) => onDropDeck(file, h?.kind === "file" ? (h as FileSystemFileHandle) : undefined))
+          .catch(() => onDropDeck(file));
+      } else {
+        onDropDeck(file);
+      }
+    },
+    [onDropDeck]
+  );
+
+  // Stored names drop the extension (see Home's upload path); the header shows
+  // it back, because ".pdf" is what makes this read as the file on disk.
+  const label = filename ? (/\.pdf$/i.test(filename) ? filename : `${filename}.pdf`) : "Untitled deck";
+
   const chip: Chip | null = remoteUpdate
     ? {
         label: "Deck updated",
@@ -117,11 +164,22 @@ export function DeckControl({
       <button
         type="button"
         onClick={onReplace}
-        title={`${filename || "This deck"} — click to swap in a different PDF`}
-        className="flex min-w-0 max-w-[14rem] items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        onDragOver={onDragOver}
+        onDragLeave={() => setDragging(false)}
+        onDrop={onDrop}
+        title={`${label} — click to swap in a different PDF${onDropDeck ? ", or drop one here" : ""}`}
+        className={cn(
+          // h-8 and px-2.5 match the header buttons; md and up widens the
+          // padding so the drop target reads as a target, not just another
+          // button.
+          "flex h-8 min-w-0 max-w-[16rem] items-center gap-1.5 rounded-md border border-dashed px-2.5 text-xs transition-colors md:px-4",
+          dragging
+            ? "border-primary/60 bg-primary/10 text-foreground"
+            : "border-border bg-muted/30 text-muted-foreground hover:bg-muted hover:text-foreground"
+        )}
       >
         <FileText size={12} className="shrink-0" />
-        <span className="truncate">{filename || "Untitled deck"}</span>
+        <span className="truncate">{label}</span>
       </button>
       {chip &&
         (chip.action === "none" ? (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -111,8 +111,8 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
-  --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
+  --border: oklch(0.35 0 0);
+  --input: oklch(0.35 0 0);
   --ring: oklch(0.439 0 0);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
@@ -125,7 +125,7 @@
   --sidebar-primary-foreground: oklch(0.205 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.269 0 0);
+  --sidebar-border: oklch(0.35 0 0);
   --sidebar-ring: oklch(0.439 0 0);
 }
 

--- a/client/src/lib/pdf.ts
+++ b/client/src/lib/pdf.ts
@@ -44,11 +44,32 @@ export async function loadPdfData(data: Uint8Array): Promise<PDFDocumentProxy> {
  *
  * A replace rewrites the stored object in place, so the deck's URL never
  * changes — and a browser (or the CDN in front of it) that already has the old
- * copy will happily serve it again. Every load that must not get the previous
- * deck goes through here, keyed by something that changes when the bytes do.
+ * copy will happily serve it again. Keyed by something that changes when the
+ * bytes do. Only for URLs we mint ourselves: see loadLatestPdf.
  */
 export function freshPdfUrl(url: string, version: string | number): string {
   return `${url}${url.includes("?") ? "&" : "?"}v=${version}`;
+}
+
+/**
+ * Load a synced deck's current bytes, whichever kind of URL it lives at.
+ *
+ * Our own storage URLs sit behind a CDN that keys on the full URL, so a version
+ * parameter is what actually defeats it. An `external` URL belongs to whoever
+ * published the deck and may be presigned, where an unknown parameter
+ * invalidates the signature outright — there, `cache: "reload"` gets fresh
+ * bytes without touching the URL, and needs no CORS preflight the way a
+ * Cache-Control request header would.
+ */
+export async function loadLatestPdf(
+  url: string,
+  { external, version }: { external: boolean; version: string | number }
+): Promise<PDFDocumentProxy> {
+  if (!external) return loadPdf(freshPdfUrl(url, version));
+  // One GET for the whole file, matching loadPdf's reasons for not ranging.
+  const res = await fetch(url, { cache: "reload" });
+  if (!res.ok) throw new Error(`Failed to fetch the PDF (${res.status})`);
+  return loadPdfData(new Uint8Array(await res.arrayBuffer()));
 }
 
 // Cap the rendered canvas width (device pixels). Beyond ~4K wide there's no

--- a/client/src/pages/ControllerView.tsx
+++ b/client/src/pages/ControllerView.tsx
@@ -93,6 +93,9 @@ interface ControllerViewProps {
   onDeckWatchCycle: () => void;
   onDeckWatchApply: () => void;
   onDeckWatchResume: () => void;
+  /** A URL-backed deck's source PDF was republished (see Presentation). */
+  remoteDeckUpdate: boolean;
+  onRemoteDeckApply: () => void;
   mediaState: MediaState;
   onMediaControl: (id: string, action: "play" | "pause" | "reset") => void;
   onMediaTime: (id: string, t: number, playing: boolean, sampledAt: number) => void;
@@ -130,6 +133,8 @@ export function ControllerView({
   onDeckWatchCycle,
   onDeckWatchApply,
   onDeckWatchResume,
+  remoteDeckUpdate,
+  onRemoteDeckApply,
   mediaState,
   onMediaControl,
   onMediaTime,
@@ -533,6 +538,8 @@ export function ControllerView({
         onDeckWatchCycle={onDeckWatchCycle}
         onDeckWatchApply={onDeckWatchApply}
         onDeckWatchResume={onDeckWatchResume}
+        remoteDeckUpdate={remoteDeckUpdate}
+        onRemoteDeckApply={onRemoteDeckApply}
         actions={isMobile ? mobileActions : desktopActions}
       />
 

--- a/client/src/pages/ControllerView.tsx
+++ b/client/src/pages/ControllerView.tsx
@@ -232,6 +232,12 @@ export function ControllerView({
   const onReplacePicked = useCallback((file: File | undefined) => {
     if (file) setReplaceCandidate(file);
   }, []);
+  // Dropped onto the deck name in the header: same confirmation as a picked
+  // replacement, and the handle (Chromium only) keeps the new deck watchable.
+  const onDeckDropped = useCallback((file: File, handle?: FileSystemFileHandle) => {
+    replaceHandleRef.current = handle ?? null;
+    setReplaceCandidate(file);
+  }, []);
   // Chromium picks via showOpenFilePicker so the replacement keeps a watchable
   // handle; other browsers fall back to the plain input (no watching).
   const openReplacePicker = useCallback(() => {
@@ -535,6 +541,7 @@ export function ControllerView({
         deckWatchMode={deckWatchMode}
         deckWatchStatus={deckWatchStatus}
         onReplaceDeck={openReplacePicker}
+        onDropDeck={onDeckDropped}
         onDeckWatchCycle={onDeckWatchCycle}
         onDeckWatchApply={onDeckWatchApply}
         onDeckWatchResume={onDeckWatchResume}

--- a/client/src/pages/ControllerView.tsx
+++ b/client/src/pages/ControllerView.tsx
@@ -90,7 +90,7 @@ interface ControllerViewProps {
   /** Live-reload preference, or null when this deck can't be watched. */
   deckWatchMode: DeckWatchMode | null;
   deckWatchStatus: DeckWatchStatus | null;
-  onDeckWatchCycle: () => void;
+  onDeckWatchModeChange: (mode: DeckWatchMode) => void;
   onDeckWatchApply: () => void;
   onDeckWatchResume: () => void;
   /** A URL-backed deck's source PDF was republished (see Presentation). */
@@ -130,7 +130,7 @@ export function ControllerView({
   filename,
   deckWatchMode,
   deckWatchStatus,
-  onDeckWatchCycle,
+  onDeckWatchModeChange,
   onDeckWatchApply,
   onDeckWatchResume,
   remoteDeckUpdate,
@@ -542,7 +542,7 @@ export function ControllerView({
         deckWatchStatus={deckWatchStatus}
         onReplaceDeck={openReplacePicker}
         onDropDeck={onDeckDropped}
-        onDeckWatchCycle={onDeckWatchCycle}
+        onDeckWatchModeChange={onDeckWatchModeChange}
         onDeckWatchApply={onDeckWatchApply}
         onDeckWatchResume={onDeckWatchResume}
         remoteDeckUpdate={remoteDeckUpdate}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -941,9 +941,8 @@ export default function Home() {
                 <div className="mb-3 flex items-start gap-2 rounded-lg border border-muted-foreground/20 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
                   <Zap size={14} className="mt-px shrink-0 text-(--home2-accent)" />
                   <p>
-                    <span className="font-medium text-foreground">Writing your talk?</span> In
-                    Chrome, Edge or another Chromium browser, Presio can watch this PDF on disk and
-                    offer the new slides each time you recompile.
+                    <span className="font-medium text-foreground">Writing your talk?</span> Use
+                    Chrome to enable live hot reload when the slides change on disk.
                   </p>
                 </div>
               )}
@@ -996,7 +995,10 @@ export default function Home() {
               {/* Outside the drop zone: a click in here must not open the
                   file picker. */}
               {watchSupported && (
-                <label className="mt-3 flex cursor-pointer items-start gap-2 text-xs text-muted-foreground">
+                <label
+                  className="mt-3 flex cursor-pointer items-start gap-2 text-xs text-muted-foreground"
+                  title="Live reload — watch this file and offer the new slides when you recompile. You're always asked before anything changes on screen; switch it off any time from the controller."
+                >
                   <input
                     type="checkbox"
                     checked={hotReload}
@@ -1004,9 +1006,8 @@ export default function Home() {
                     className="mt-0.5 h-3.5 w-3.5 shrink-0 accent-(--home2-accent)"
                   />
                   <span>
-                    <span className="font-medium text-foreground">Live reload</span> — watch this
-                    file and offer the new slides when you recompile. You&apos;re always asked
-                    before anything changes on screen; switch it off any time from the controller.
+                    <span className="font-medium text-foreground">Hot reload</span> — update
+                    presentation if file changes on disk.
                   </span>
                 </label>
               )}

--- a/client/src/pages/Presentation.tsx
+++ b/client/src/pages/Presentation.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { useParams, useSearchParams, useNavigate, useLocation, Link } from "react-router-dom";
 import type { PDFDocumentProxy } from "pdfjs-dist";
 import { getDocument } from "pdfjs-dist";
-import { loadPdf, loadPdfData, freshPdfUrl, renderPage, clearCache } from "@/lib/pdf";
+import { loadPdf, loadPdfData, freshPdfUrl, loadLatestPdf, renderPage, clearCache } from "@/lib/pdf";
 import { loadDeckInfo, type Deck, type DeckInfo } from "@/lib/deck";
 import { setSlideNotes } from "@/lib/notesAttach";
 import { defaultAudioState, isMutedForRole, type MediaState, type MediaTimeSync, type AudioState } from "@/lib/media";
@@ -157,12 +157,27 @@ export default function Presentation() {
   });
   const deckWatchModeRef = useRef(deckWatchMode);
   deckWatchModeRef.current = deckWatchMode;
-  // A detected recompile waiting on the presenter (prompt mode only).
-  const [reloadPrompt, setReloadPrompt] = useState(false);
+  // A detected deck change waiting on the presenter: "watch" from the file
+  // watcher (prompt mode only), "remote" from the URL-republish poller. Both
+  // clear drawings and Presio-edited notes, so both get the same warning.
+  const [reloadPrompt, setReloadPrompt] = useState<"watch" | "remote" | null>(null);
   const [applyingWatch, setApplyingWatch] = useState(false);
   // Speaker notes edited in Presio live in the current PDF's bytes, so a
   // recompiled file replaces them. Tracked to warn before that happens.
   const [notesEdited, setNotesEdited] = useState(false);
+
+  // A URL-backed deck's source PDF was republished (remote-version polling
+  // below); held until the presenter applies it or the poller replaces it
+  // with a newer sighting. Null = nothing pending.
+  const [remoteUpdate, setRemoteUpdate] = useState<{ totalSlides: number } | null>(null);
+  // Whether pdfUrl points at someone else's host (a URL-backed deck) rather
+  // than our own storage. Decides how a changed deck is re-fetched.
+  const [externalPdf, setExternalPdf] = useState(false);
+  const externalPdfRef = useRef(false);
+  externalPdfRef.current = externalPdf;
+  // The republished deck, already downloaded and parsed by the poller to
+  // confirm it. Handed to applyDeckUpdate so applying costs no second download.
+  const prefetchedDeckRef = useRef<PDFDocumentProxy | null>(null);
 
   useEffect(() => {
     // The settled role, not the requested one: a second controller demoted to
@@ -190,7 +205,7 @@ export default function Presentation() {
             // Auto mode swaps without asking; prompt mode puts the decision
             // (and what it costs) in front of the presenter first.
             if (deckWatchModeRef.current === "auto") void applyDeckWatchUpdateRef.current();
-            else setReloadPrompt(true);
+            else setReloadPrompt("watch");
           },
         });
         watcherRef.current = watcher;
@@ -205,7 +220,7 @@ export default function Presentation() {
       watcherRef.current?.stop();
       watcherRef.current = null;
       setDeckWatchStatus(null);
-      setReloadPrompt(false);
+      setReloadPrompt((p) => (p === "watch" ? null : p));
     };
   }, [local, id, role, watchedHandleEpoch, deckWatchMode]);
 
@@ -266,10 +281,22 @@ export default function Presentation() {
             localUrlRef.current = url;
             setPdfUrl(url);
           } else {
-            // The stored object path doesn't change on replace, so bust any
-            // cached copy along the way before re-fetching.
             clearCache();
-            const doc = await loadPdf(freshPdfUrl(pdfUrlRef.current, Date.now()));
+            // The remote-version poller already downloaded and parsed the
+            // republished deck to confirm it. When this update is that one,
+            // adopt the document it has rather than fetching the same bytes
+            // again mid-presentation.
+            const prefetched = prefetchedDeckRef.current;
+            prefetchedDeckRef.current = null;
+            if (prefetched && prefetched.numPages === totalSlides) {
+              setPdf(prefetched);
+              return;
+            }
+            void prefetched?.destroy();
+            const doc = await loadLatestPdf(pdfUrlRef.current, {
+              external: externalPdfRef.current,
+              version: Date.now(),
+            });
             setPdf(doc);
           }
         } catch {
@@ -314,6 +341,7 @@ export default function Presentation() {
         }
         if (cancelled) return;
         setLocal(false);
+        setExternalPdf(!!session.external);
         // Arriving straight from a replace (Home's recents/re-upload flow) the
         // stored object has new bytes at the same URL, and this browser is the
         // one most likely to have the old copy cached — it had the deck open
@@ -737,6 +765,181 @@ export default function Presentation() {
     return { "x-controller-token": controllerToken };
   }, [id]);
 
+  // Remote republish watching for URL-backed decks. A deck loaded from an
+  // external link re-fetches its PDF on every load, so a republish at the
+  // same URL is only invisible to a session that is already running. The
+  // controller polls the server's cheap metadata endpoint (one poller per
+  // session — viewers never poll) and, when the remote file provably changed,
+  // offers the new deck through the header pill. Same house rule as the file
+  // watcher: nothing swaps until the presenter clicks, and nothing surfaces
+  // when the host is unreachable or doesn't support the check.
+  useEffect(() => {
+    if (local !== false || role !== "controller") return;
+    const base = pdfUrlRef.current;
+    if (!base || base.startsWith("blob:")) return;
+
+    const BASE_MS = 30_000;
+    const MAX_MS = 4 * 60_000;
+    interface Sig {
+      etag: string;
+      lastModified: string;
+      contentLength: string;
+    }
+    const same = (a: Sig, b: Sig) =>
+      a.etag === b.etag && a.lastModified === b.lastModified && a.contentLength === b.contentLength;
+    const hasValidators = (s: Sig) => !!(s.etag || s.lastModified || s.contentLength);
+
+    let stopped = false;
+    let busy = false; // a poll's probes + parse can outlast one interval; never overlap
+    let backedOff = false; // parked at the slow cadence by an unreachable host
+    let delay = BASE_MS;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let baseline: Sig | null = null;
+    let candidate: Sig | null = null;
+
+    const stop = () => {
+      stopped = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+    const schedule = () => {
+      if (stopped) return;
+      timer = setTimeout(() => { void poll(); }, delay);
+    };
+
+    const poll = async () => {
+      if (stopped || busy) return;
+      // Frozen background tabs can't present anyway; skip the round without
+      // spending a request on the remote host.
+      if (document.hidden) {
+        schedule();
+        return;
+      }
+      busy = true;
+      try {
+        let headers: Record<string, string>;
+        try {
+          headers = await pdfWriteAuth();
+        } catch {
+          stop(); // no credential to poll with — degrade silently
+          return;
+        }
+        let sig: Sig;
+        try {
+          const res = await fetch(`/api/sessions/${id}/remote-version`, { headers });
+          if (res.status === 403 || res.status === 404) {
+            stop(); // session gone, or not URL-backed: nothing to watch
+            return;
+          }
+          if (!res.ok) {
+            // Remote host unreachable (the server answers 502): back off to
+            // the slowest cadence and keep trying, still silently.
+            delay = MAX_MS;
+            backedOff = true;
+            schedule();
+            return;
+          }
+          sig = await res.json();
+          if (backedOff) {
+            // The host answered again. Without this the session stays parked at
+            // the four-minute cadence for good, since only a confirmed change
+            // resets it — and it can't see one while the host is down.
+            backedOff = false;
+            delay = BASE_MS;
+          }
+        } catch {
+          stop(); // network failure — today's behaviour, without errors
+          return;
+        }
+        if (!hasValidators(sig)) {
+          stop(); // host sends no validators — there is nothing to compare
+          return;
+        }
+        if (!baseline) {
+          baseline = sig; // first observation is the reference, never a change
+          schedule();
+          return;
+        }
+        if (same(sig, baseline)) {
+          candidate = null;
+          delay = Math.min(delay * 2, MAX_MS); // polite backoff while unchanged
+          schedule();
+          return;
+        }
+        // Different from the baseline. Hosts behind some CDNs mint a fresh
+        // ETag per request, so require the new signature to hold steady
+        // across two consecutive polls before trusting it.
+        if (!candidate || !same(sig, candidate)) {
+          candidate = sig;
+          schedule();
+          return;
+        }
+        // Confirmed change: read the new document's page count before
+        // offering it, so applying clamps correctly. A parse failure means
+        // the publish is probably mid-flight — keep watching silently and
+        // re-detect on the next poll.
+        candidate = null;
+        try {
+          // Always external here: the server only answers remote-version for a
+          // deck backed by someone else's URL.
+          const doc = await loadLatestPdf(base, { external: true, version: Date.now() });
+          if (stopped) {
+            void doc.destroy();
+            return;
+          }
+          // Keep it: if the presenter applies this update, applyDeckUpdate
+          // adopts the document instead of downloading the same bytes again.
+          void prefetchedDeckRef.current?.destroy();
+          prefetchedDeckRef.current = doc;
+          baseline = sig;
+          delay = BASE_MS; // stay fast for a while after a real change
+          setRemoteUpdate({ totalSlides: doc.numPages });
+          setReloadPrompt("remote");
+        } catch {
+          // candidate stays null: the next poll re-confirms and retries.
+        }
+        schedule();
+      } finally {
+        busy = false;
+      }
+    };
+
+    schedule();
+    return () => {
+      stop();
+      void prefetchedDeckRef.current?.destroy();
+      prefetchedDeckRef.current = null;
+    };
+  }, [local, role, id, pdfUrl, pdfWriteAuth]);
+
+  // Pill click: announce the republished deck for controller and viewers via
+  // the server's deck_updated broadcast — every client (this one included)
+  // cache-busts the URL and reloads through the ordinary deck_updated path.
+  const applyRemoteDeckUpdate = useCallback(async () => {
+    if (!remoteUpdate || applyingWatch) return;
+    setApplyingWatch(true);
+    try {
+      const authHeaders = await pdfWriteAuth();
+      const res = await fetch(`/api/sessions/${id}/deck-refreshed`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ total_slides: remoteUpdate.totalSlides }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Failed to apply the updated deck");
+      }
+      setRemoteUpdate(null);
+      setReloadPrompt(null);
+    } catch (e) {
+      window.alert(e instanceof Error ? e.message : "Failed to apply the updated deck");
+    } finally {
+      setApplyingWatch(false);
+    }
+  }, [remoteUpdate, applyingWatch, id, pdfWriteAuth]);
+
   // Persist edited speaker notes by writing them back into the PDF as a JSON
   // sidecar (matching presio's format), then swap in the updated document so
   // further edits build on it. Local sessions update IndexedDB; synced ones
@@ -885,7 +1088,7 @@ export default function Presentation() {
       // replace leaves the update pending and the pill clickable.
       watcher.adopt(update.meta);
       setDeckWatchStatus("watching");
-      setReloadPrompt(false);
+      setReloadPrompt(null);
     } catch (e) {
       window.alert(e instanceof Error ? e.message : "Failed to replace the PDF");
     } finally {
@@ -1106,15 +1309,16 @@ export default function Presentation() {
       {reloadPrompt && (
         <ConfirmDeckReloadDialog
           filename={filename}
+          source={reloadPrompt}
           annotatedSlides={
             Object.values(annotations).filter((strokes) => strokes.length > 0).length
           }
           notesEdited={notesEdited}
           busy={applyingWatch}
-          onConfirm={applyDeckWatchUpdate}
+          onConfirm={reloadPrompt === "watch" ? applyDeckWatchUpdate : applyRemoteDeckUpdate}
           // Dismissed, not declined: the header keeps the "Deck updated" chip
-          // so the recompile can still be applied when the moment is right.
-          onClose={() => setReloadPrompt(false)}
+          // so the update can still be applied when the moment is right.
+          onClose={() => setReloadPrompt(null)}
         />
       )}
       <ControllerView
@@ -1136,6 +1340,8 @@ export default function Presentation() {
         onDeckWatchCycle={cycleDeckWatchMode}
         onDeckWatchApply={applyDeckWatchUpdate}
         onDeckWatchResume={resumeDeckWatch}
+        remoteDeckUpdate={!!remoteUpdate}
+        onRemoteDeckApply={applyRemoteDeckUpdate}
         onBlankToggle={() => {
           const next = !blanked;
           // Server mode learns the new state from the socket echo; local mode has

--- a/client/src/pages/Presentation.tsx
+++ b/client/src/pages/Presentation.tsx
@@ -750,19 +750,27 @@ export default function Presentation() {
     navigate("/", { replace: true });
   }, [local, id, navigate]);
 
-  // Authorization for rewriting a synced deck's stored PDF. A logged-in owner
-  // sends their bearer token; a presenter holding only the controller token
-  // (anonymous creation, local-mode server, passphrase-granted controllers)
-  // sends that — the server accepts both, exactly like ending a session.
+  // Authorization for rewriting a synced deck's stored PDF. The server accepts
+  // either the presentation's controller token or the logged-in owner's bearer
+  // token, so send whichever this browser has — and both when it has both.
+  //
+  // Sending only the bearer token used to be enough for the common case and
+  // wrong for one that matters: a signed-in presenter who took control by
+  // passphrase isn't the owner, so their token doesn't authorize the write and
+  // the controller token that would was never sent.
   const pdfWriteAuth = useCallback(async (): Promise<Record<string, string>> => {
+    const headers: Record<string, string> = {};
+    const { controllerToken } = getSessionAuth(id!);
+    if (controllerToken) headers["x-controller-token"] = controllerToken;
     if (authEnabled) {
       const { data } = await supabase.auth.getSession();
       const accessToken = data.session?.access_token;
-      if (accessToken) return { Authorization: `Bearer ${accessToken}` };
+      if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
     }
-    const { controllerToken } = getSessionAuth(id!);
-    if (!controllerToken) throw new Error("This browser isn't the controller for this presentation");
-    return { "x-controller-token": controllerToken };
+    if (!Object.keys(headers).length) {
+      throw new Error("This browser isn't the controller for this presentation");
+    }
+    return headers;
   }, [id]);
 
   // Remote republish watching for URL-backed decks. A deck loaded from an

--- a/client/src/pages/Presentation.tsx
+++ b/client/src/pages/Presentation.tsx
@@ -26,7 +26,6 @@ import {
   DeckWatcher,
   isDeckWatchSupported,
   isDeckWatchMode,
-  nextDeckWatchMode,
   type DeckWatchMode,
   type DeckWatchStatus,
 } from "@/lib/deckWatcher";
@@ -229,8 +228,10 @@ export default function Presentation() {
     if (local && role === "controller") lsSetString(deckWatchKey(id!), deckWatchMode);
   }, [deckWatchMode, local, role, id]);
 
-  const cycleDeckWatchMode = useCallback(() => {
-    setDeckWatchMode((mode) => nextDeckWatchMode(mode));
+  // Picked from the header's live-reload menu. The effect above persists it,
+  // so a mode chosen here survives a controller reload.
+  const chooseDeckWatchMode = useCallback((mode: DeckWatchMode) => {
+    setDeckWatchMode(mode);
   }, []);
 
   // Persist the controller's drawings across reloads.
@@ -1345,7 +1346,7 @@ export default function Presentation() {
         filename={filename}
         deckWatchMode={deckWatchable ? deckWatchMode : null}
         deckWatchStatus={deckWatchStatus}
-        onDeckWatchCycle={cycleDeckWatchMode}
+        onDeckWatchModeChange={chooseDeckWatchMode}
         onDeckWatchApply={applyDeckWatchUpdate}
         onDeckWatchResume={resumeDeckWatch}
         remoteDeckUpdate={!!remoteUpdate}

--- a/server/agent/content/api.md
+++ b/server/agent/content/api.md
@@ -71,6 +71,18 @@ curl -s -F file=@deck.pdf BASE/api/check
   **200:** `[{ id, filename, total_slides, created_at, expires_at, controllerToken }]`. `controllerToken` is included because the owner is entitled to it — it lets any device the user signs in on open the presentation as its controller. 401 without a valid token; not available in local mode.
 - `DELETE /api/sessions/:id` — header `x-controller-token` — end a presentation: viewers are disconnected, the PDF is removed, and the row is marked expired (not recoverable).
 
+## URL-backed decks (republish detection)
+
+Presentations created with `POST /api/sessions/external` point at a PDF hosted elsewhere. A running session can detect that the file at the source URL was republished and swap it in live, without re-uploading anything.
+
+- `GET /api/sessions/:id/remote-version` — header `x-controller-token` (or `Authorization: Bearer <login JWT>` for the owner) — cheap change detection for a URL-backed deck. The server probes the deck's source URL with a HEAD request (a one-byte ranged GET for hosts that reject HEAD) and returns the validator tuple:
+  **200:** `{ etag, lastModified, contentLength }` — each field an opaque string, `""` when the host does not send it. Nothing is downloaded.
+  - **404** when the session is unknown or expired, or is **not URL-backed** (local and server-hosted decks have no `pdf_url`) — treat this as "nothing to watch".
+  - **502** when the remote host is unreachable or errors — back off and retry later; the session keeps working with its current deck.
+  - **403** on a wrong controller token.
+- `POST /api/sessions/:id/deck-refreshed` — same auth — the presenter accepted a republished deck. Body: `{ "total_slides": N }` (the new page count, read from the republished PDF). Records the new page count, clamps the stored current slide into range, drops the stored drawings, and broadcasts `deck_updated` to the room so every connected client re-fetches the source URL.
+  **200:** `{ ok: true, totalSlides, filename }`. **400** for a missing/invalid `total_slides` or a presentation that is not URL-backed. No bytes are uploaded — `pdf_url` decks keep no server copy.
+
 ## OpenAPI
 
 Machine-readable: `BASE/openapi.json`

--- a/server/agent/content/api.md
+++ b/server/agent/content/api.md
@@ -78,8 +78,10 @@ Presentations created with `POST /api/sessions/external` point at a PDF hosted e
 - `GET /api/sessions/:id/remote-version` — header `x-controller-token` (or `Authorization: Bearer <login JWT>` for the owner) — cheap change detection for a URL-backed deck. The server probes the deck's source URL with a HEAD request (a one-byte ranged GET for hosts that reject HEAD) and returns the validator tuple:
   **200:** `{ etag, lastModified, contentLength }` — each field an opaque string, `""` when the host does not send it. Nothing is downloaded.
   - **404** when the session is unknown or expired, or is **not URL-backed** (local and server-hosted decks have no `pdf_url`) — treat this as "nothing to watch".
-  - **502** when the remote host is unreachable or errors — back off and retry later; the session keeps working with its current deck.
+  - **502** when the remote host is unreachable or errors, or when the URL is one the server refuses to fetch — back off and retry later; the session keeps working with its current deck.
   - **403** on a wrong controller token.
+
+  The probe is https-only and restricted to public addresses: a `pdf_url` that resolves to a loopback, private, link-local or otherwise internal address is refused, and redirects are followed only while they stay https and public. A deck hosted somewhere only reachable inside a private network can be presented as normal — it just gets no republish detection.
 - `POST /api/sessions/:id/deck-refreshed` — same auth — the presenter accepted a republished deck. Body: `{ "total_slides": N }` (the new page count, read from the republished PDF). Records the new page count, clamps the stored current slide into range, drops the stored drawings, and broadcasts `deck_updated` to the room so every connected client re-fetches the source URL.
   **200:** `{ ok: true, totalSlides, filename }`. **400** for a missing/invalid `total_slides` or a presentation that is not URL-backed. No bytes are uploaded — `pdf_url` decks keep no server copy.
 

--- a/server/agent/openapi.ts
+++ b/server/agent/openapi.ts
@@ -198,7 +198,7 @@ export function buildOpenApi(base: string) {
         get: {
           summary: "Change-detection metadata for a URL-backed deck's remote PDF",
           description:
-            "Probes the deck's source URL with a HEAD request (one-byte ranged GET fallback) and returns its validator headers, so a running controller can tell whether the remote PDF was republished — without downloading it. Only for presentations backed by an external PDF URL.",
+            "Probes the deck's source URL with a HEAD request (one-byte ranged GET fallback) and returns its validator headers, so a running controller can tell whether the remote PDF was republished — without downloading it. Only for presentations backed by an external PDF URL. The probe is https-only and restricted to public addresses (loopback, private and link-local targets are refused, and redirects are re-checked at every hop).",
           operationId: "remoteSessionVersion",
           parameters: [
             { name: "id", in: "path", required: true, schema: { type: "string" } },
@@ -232,7 +232,10 @@ export function buildOpenApi(base: string) {
               description:
                 "Unknown or expired session, or the presentation is not backed by an external URL (local and server-hosted decks have no pdf_url) — nothing to watch",
             },
-            "502": { description: "The remote host could not be reached" },
+            "502": {
+              description:
+                "The remote host could not be reached, or the URL is one the server refuses to fetch",
+            },
           },
         },
       },

--- a/server/agent/openapi.ts
+++ b/server/agent/openapi.ts
@@ -194,6 +194,105 @@ export function buildOpenApi(base: string) {
           },
         },
       },
+      "/api/sessions/{id}/remote-version": {
+        get: {
+          summary: "Change-detection metadata for a URL-backed deck's remote PDF",
+          description:
+            "Probes the deck's source URL with a HEAD request (one-byte ranged GET fallback) and returns its validator headers, so a running controller can tell whether the remote PDF was republished — without downloading it. Only for presentations backed by an external PDF URL.",
+          operationId: "remoteSessionVersion",
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" } },
+            {
+              name: "x-controller-token",
+              in: "header",
+              required: true,
+              schema: { type: "string" },
+              description: "Controller token (or Authorization: Bearer for the logged-in owner)",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Validator tuple; each field is \"\" when the host does not send it",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["etag", "lastModified", "contentLength"],
+                    properties: {
+                      etag: { type: "string" },
+                      lastModified: { type: "string" },
+                      contentLength: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "403": { description: "Wrong controller token" },
+            "404": {
+              description:
+                "Unknown or expired session, or the presentation is not backed by an external URL (local and server-hosted decks have no pdf_url) — nothing to watch",
+            },
+            "502": { description: "The remote host could not be reached" },
+          },
+        },
+      },
+      "/api/sessions/{id}/deck-refreshed": {
+        post: {
+          summary: "Announce a republished URL-backed deck to the room",
+          description:
+            "The presenter accepted a deck that was republished at its source URL. Records the new page count, clamps the stored current slide into range, drops the stored drawings, and broadcasts deck_updated so every connected client re-fetches the source URL. No bytes are uploaded — pdf_url decks keep no server copy.",
+          operationId: "deckRefreshed",
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" } },
+            {
+              name: "x-controller-token",
+              in: "header",
+              required: true,
+              schema: { type: "string" },
+              description: "Controller token (or Authorization: Bearer for the logged-in owner)",
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["total_slides"],
+                  properties: {
+                    total_slides: {
+                      type: "integer",
+                      description: "The republished PDF's page count, as read by the client",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "OK",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      ok: { type: "boolean" },
+                      totalSlides: { type: "integer" },
+                      filename: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Missing or invalid total_slides, or the presentation is not URL-backed",
+            },
+            "403": { description: "Wrong controller token" },
+            "404": { description: "Unknown or expired session id" },
+          },
+        },
+      },
       "/api/sessions/{id}": {
         delete: {
           summary: "End a presentation",

--- a/server/lib/remotePdf.test.ts
+++ b/server/lib/remotePdf.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// DNS is the gate the URL safety check turns on, so drive it directly rather
+// than depending on what the test machine can resolve.
+const resolved = new Map<string, string[]>();
+vi.mock("node:dns/promises", () => ({
+  lookup: async (host: string, _opts?: unknown) => {
+    const addrs = resolved.get(host);
+    if (!addrs) throw new Error("ENOTFOUND");
+    return addrs.map((address) => ({ address, family: address.includes(":") ? 6 : 4 }));
+  },
+}));
+
+const { isPublicAddress, isSafeRemoteUrl, metaFromHeaders, fetchRemotePdfMeta } = await import(
+  "./remotePdf.js"
+);
+
+const realFetch = globalThis.fetch;
+beforeEach(() => {
+  resolved.clear();
+  resolved.set("cdn.example.com", ["93.184.216.34"]);
+});
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+type StubResponse = { status: number; headers?: Record<string, string> };
+
+/**
+ * Stub `fetch` with a per-URL routing table (so a redirect target answers
+ * differently from its source, and HEAD and GET see the same host), recording
+ * every request that was actually made.
+ */
+function stubFetch(routes: Record<string, StubResponse>, fallback?: StubResponse) {
+  const calls: { url: string; method: string }[] = [];
+  globalThis.fetch = (async (url: string | URL, init?: RequestInit) => {
+    const href = String(url);
+    calls.push({ url: href, method: init?.method ?? "GET" });
+    const spec = routes[href] ?? fallback;
+    if (!spec) throw new Error(`unexpected fetch: ${href}`);
+    return new Response(null, { status: spec.status, headers: spec.headers });
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("isPublicAddress", () => {
+  it("rejects loopback, private, link-local and multicast v4", () => {
+    for (const ip of [
+      "127.0.0.1",
+      "10.1.2.3",
+      "172.16.0.1",
+      "172.31.255.255",
+      "192.168.1.1",
+      "169.254.169.254", // cloud metadata
+      "100.64.0.1",
+      "0.0.0.0",
+      "224.0.0.1",
+      "255.255.255.255",
+    ]) {
+      expect(isPublicAddress(ip), ip).toBe(false);
+    }
+  });
+
+  it("rejects loopback, unique-local, link-local and IPv4-mapped v6", () => {
+    for (const ip of [
+      "::1",
+      "0:0:0:0:0:0:0:1", // the same address, written long
+      "::",
+      "fd00::1",
+      "fe80::1",
+      "ff02::1",
+      "::ffff:127.0.0.1",
+      "::ffff:10.0.0.1",
+    ]) {
+      expect(isPublicAddress(ip), ip).toBe(false);
+    }
+  });
+
+  it("accepts ordinary public addresses", () => {
+    expect(isPublicAddress("93.184.216.34")).toBe(true);
+    expect(isPublicAddress("2606:2800:220:1:248:1893:25c8:1946")).toBe(true);
+  });
+
+  it("rejects anything that isn't an IP address", () => {
+    expect(isPublicAddress("example.com")).toBe(false);
+    expect(isPublicAddress("")).toBe(false);
+  });
+});
+
+describe("isSafeRemoteUrl", () => {
+  it("accepts an https URL resolving to a public address", async () => {
+    expect(await isSafeRemoteUrl("https://cdn.example.com/deck.pdf")).toBe(true);
+  });
+
+  it("rejects a name resolving to a private address", async () => {
+    resolved.set("internal.example.com", ["10.0.0.5"]);
+    expect(await isSafeRemoteUrl("https://internal.example.com/deck.pdf")).toBe(false);
+  });
+
+  it("rejects a name resolving to the cloud metadata address", async () => {
+    resolved.set("evil.example.com", ["169.254.169.254"]);
+    expect(await isSafeRemoteUrl("https://evil.example.com/")).toBe(false);
+  });
+
+  it("rejects a name that answers with a private address alongside a public one", async () => {
+    resolved.set("split.example.com", ["93.184.216.34", "127.0.0.1"]);
+    expect(await isSafeRemoteUrl("https://split.example.com/")).toBe(false);
+  });
+
+  it("rejects private IP literals without consulting DNS", async () => {
+    expect(await isSafeRemoteUrl("https://127.0.0.1:8443/")).toBe(false);
+    expect(await isSafeRemoteUrl("https://169.254.169.254/latest/meta-data/")).toBe(false);
+    expect(await isSafeRemoteUrl("https://[::1]/")).toBe(false);
+  });
+
+  it("rejects anything that isn't https, and unresolvable names", async () => {
+    expect(await isSafeRemoteUrl("http://cdn.example.com/deck.pdf")).toBe(false);
+    expect(await isSafeRemoteUrl("file:///etc/passwd")).toBe(false);
+    expect(await isSafeRemoteUrl("not a url")).toBe(false);
+    expect(await isSafeRemoteUrl("https://nowhere.example.com/")).toBe(false);
+  });
+});
+
+describe("metaFromHeaders", () => {
+  it("reads the validators a host sends", () => {
+    const h = new Headers({
+      etag: '"abc"',
+      "last-modified": "Wed, 27 Aug 2026 10:00:00 GMT",
+      "content-length": "48213",
+    });
+    expect(metaFromHeaders(h, false)).toEqual({
+      etag: '"abc"',
+      lastModified: "Wed, 27 Aug 2026 10:00:00 GMT",
+      contentLength: "48213",
+    });
+  });
+
+  it("uses empty strings for validators the host omits", () => {
+    expect(metaFromHeaders(new Headers(), false)).toEqual({
+      etag: "",
+      lastModified: "",
+      contentLength: "",
+    });
+  });
+
+  it("takes the total size out of Content-Range on a ranged probe", () => {
+    // A 206's own Content-Length is the range size (1 byte), not the file's.
+    const h = new Headers({ "content-length": "1", "content-range": "bytes 0-0/48213" });
+    expect(metaFromHeaders(h, true).contentLength).toBe("48213");
+  });
+
+  it("keeps Content-Length when Content-Range is missing or unparseable", () => {
+    expect(metaFromHeaders(new Headers({ "content-length": "1" }), true).contentLength).toBe("1");
+    const odd = new Headers({ "content-length": "1", "content-range": "bytes 0-0/*" });
+    expect(metaFromHeaders(odd, true).contentLength).toBe("1");
+  });
+});
+
+describe("fetchRemotePdfMeta", () => {
+  it("returns the validators from a HEAD, without a GET", async () => {
+    const calls = stubFetch({
+      "https://cdn.example.com/deck.pdf": {
+        status: 200,
+        headers: { etag: '"v1"', "content-length": "10" },
+      },
+    });
+    const meta = await fetchRemotePdfMeta("https://cdn.example.com/deck.pdf");
+    expect(meta).toEqual({ etag: '"v1"', lastModified: "", contentLength: "10" });
+    expect(calls).toEqual([{ url: "https://cdn.example.com/deck.pdf", method: "HEAD" }]);
+  });
+
+  it("falls back to a one-byte ranged GET for hosts that reject HEAD", async () => {
+    const methods: string[] = [];
+    globalThis.fetch = (async (_url: string | URL, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      methods.push(method);
+      return method === "HEAD"
+        ? new Response(null, { status: 405 }) // Method Not Allowed
+        : new Response(null, {
+            status: 206,
+            headers: { etag: '"v1"', "content-range": "bytes 0-0/900" },
+          });
+    }) as typeof fetch;
+    const meta = await fetchRemotePdfMeta("https://cdn.example.com/deck.pdf");
+    expect(meta?.contentLength).toBe("900");
+    expect(methods).toEqual(["HEAD", "GET"]);
+  });
+
+  it("refuses a URL pointing at a private host outright", async () => {
+    const calls = stubFetch({}, { status: 200 });
+    expect(await fetchRemotePdfMeta("https://169.254.169.254/latest/meta-data/")).toBeNull();
+    expect(calls).toEqual([]); // never even connected
+  });
+
+  it("re-validates each redirect hop, so a public host can't bounce to a private one", async () => {
+    resolved.set("attacker.example.com", ["93.184.216.34"]);
+    const calls = stubFetch(
+      {
+        "https://attacker.example.com/deck.pdf": {
+          status: 302,
+          headers: { location: "https://169.254.169.254/latest/meta-data/" },
+        },
+      },
+      // Would hand back a validator if the redirect were ever followed.
+      { status: 200, headers: { etag: '"leaked"' } }
+    );
+    expect(await fetchRemotePdfMeta("https://attacker.example.com/deck.pdf")).toBeNull();
+    // Only the attacker's own host was ever contacted (once for HEAD, once for
+    // the GET fallback); the metadata address was refused before connecting.
+    expect(new Set(calls.map((c) => c.url))).toEqual(
+      new Set(["https://attacker.example.com/deck.pdf"])
+    );
+  });
+
+  it("follows a redirect that stays on a public https host", async () => {
+    resolved.set("links.example.com", ["93.184.216.34"]);
+    const calls = stubFetch({
+      "https://links.example.com/d": {
+        status: 301,
+        headers: { location: "https://cdn.example.com/deck.pdf" },
+      },
+      "https://cdn.example.com/deck.pdf": { status: 200, headers: { etag: '"v2"' } },
+    });
+    const meta = await fetchRemotePdfMeta("https://links.example.com/d");
+    expect(meta?.etag).toBe('"v2"');
+    expect(calls[1].url).toBe("https://cdn.example.com/deck.pdf");
+  });
+
+  it("gives up on an endless redirect chain", async () => {
+    resolved.set("loop.example.com", ["93.184.216.34"]);
+    const calls = stubFetch({
+      "https://loop.example.com/x": {
+        status: 302,
+        headers: { location: "https://loop.example.com/x" },
+      },
+    });
+    expect(await fetchRemotePdfMeta("https://loop.example.com/x")).toBeNull();
+    // Bounded, not endless: a handful of hops for HEAD and again for GET.
+    expect(calls.length).toBeLessThanOrEqual(10);
+  });
+
+  it("returns null when the host errors or is unreachable", async () => {
+    stubFetch({}, { status: 500 });
+    expect(await fetchRemotePdfMeta("https://cdn.example.com/deck.pdf")).toBeNull();
+
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    expect(await fetchRemotePdfMeta("https://cdn.example.com/deck.pdf")).toBeNull();
+  });
+
+  it("never downloads a body", async () => {
+    const cancel = vi.fn(async () => {});
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        headers: new Headers({ etag: '"v1"' }),
+        body: { cancel },
+      }) as unknown as Response) as typeof fetch;
+    await fetchRemotePdfMeta("https://cdn.example.com/deck.pdf");
+    expect(cancel).toHaveBeenCalled();
+  });
+});

--- a/server/lib/remotePdf.ts
+++ b/server/lib/remotePdf.ts
@@ -1,0 +1,172 @@
+// Probing the PDF behind a URL-backed presentation for *whether it changed*,
+// without downloading it.
+//
+// This is the one place the server dereferences a URL a visitor supplied
+// (`POST /api/sessions/external` takes any well-formed https URL, from anyone),
+// so it is also the app's whole SSRF surface. Two rules keep it narrow:
+//
+//   1. Every hop must resolve entirely to public addresses. A name that
+//      resolves to anything loopback/private/link-local is refused, so the
+//      probe can't be aimed at a cloud metadata endpoint or an internal service.
+//   2. Redirects are followed by hand, https-only, and re-validated at every
+//      hop — `redirect: "follow"` would let an attacker-controlled public host
+//      bounce the request straight to 169.254.169.254.
+//
+// Residual risk worth knowing about: validation happens just before the
+// connection, not as part of it, so a name that changes answers between the
+// two (DNS rebinding) can still slip past. Closing that needs a connect-time
+// hook (an undici dispatcher, which would be a new dependency). What leaks in
+// that window is bounded to the three validator headers below — never a body.
+
+import { lookup } from "node:dns/promises";
+import net from "node:net";
+
+/** Cheap change-detection metadata for a remote PDF: the host's validator
+ *  headers, as available. Opaque strings only — the body is never downloaded. */
+export interface RemotePdfMeta {
+  etag: string;
+  lastModified: string;
+  contentLength: string;
+}
+
+const REMOTE_PROBE_TIMEOUT_MS = 5_000;
+const MAX_REDIRECTS = 3;
+// A probe holds a server socket for up to two timeouts (HEAD, then the ranged
+// GET fallback). Cap how many can be in flight at once so a burst of polls
+// against a slow host can't tie the process up.
+const MAX_CONCURRENT_PROBES = 8;
+
+// Address ranges a presentation's PDF can never legitimately live on.
+const blocked = new net.BlockList();
+blocked.addSubnet("0.0.0.0", 8, "ipv4"); // "this network"
+blocked.addSubnet("10.0.0.0", 8, "ipv4");
+blocked.addSubnet("100.64.0.0", 10, "ipv4"); // carrier-grade NAT
+blocked.addSubnet("127.0.0.0", 8, "ipv4"); // loopback
+blocked.addSubnet("169.254.0.0", 16, "ipv4"); // link-local — cloud metadata
+blocked.addSubnet("172.16.0.0", 12, "ipv4");
+blocked.addSubnet("192.0.0.0", 24, "ipv4"); // IETF protocol assignments
+blocked.addSubnet("192.0.2.0", 24, "ipv4"); // documentation
+blocked.addSubnet("192.168.0.0", 16, "ipv4");
+blocked.addSubnet("198.18.0.0", 15, "ipv4"); // benchmarking
+blocked.addSubnet("198.51.100.0", 24, "ipv4"); // documentation
+blocked.addSubnet("203.0.113.0", 24, "ipv4"); // documentation
+blocked.addSubnet("224.0.0.0", 4, "ipv4"); // multicast
+blocked.addSubnet("240.0.0.0", 4, "ipv4"); // reserved + broadcast
+blocked.addAddress("::", "ipv6");
+blocked.addAddress("::1", "ipv6"); // loopback
+blocked.addSubnet("fc00::", 7, "ipv6"); // unique-local
+blocked.addSubnet("fe80::", 10, "ipv6"); // link-local
+blocked.addSubnet("ff00::", 8, "ipv6"); // multicast
+blocked.addSubnet("64:ff9b::", 96, "ipv6"); // NAT64
+// IPv4-mapped forms (::ffff:127.0.0.1) need no rule of their own: BlockList
+// already checks them against the IPv4 rules above. Adding ::ffff:0:0/96
+// explicitly would be worse than redundant — it makes *every* plain IPv4
+// address match, since BlockList maps those into the same range to compare.
+
+/** Whether a literal IP address is one a public PDF host could have. */
+export function isPublicAddress(ip: string): boolean {
+  const family = net.isIP(ip);
+  if (family === 4) return !blocked.check(ip, "ipv4");
+  if (family === 6) return !blocked.check(ip, "ipv6");
+  return false;
+}
+
+/**
+ * Whether this URL is safe for the server to dereference: https, and resolving
+ * only to public addresses. Every address a name resolves to must be public —
+ * a name answering with both a public and a private address is still an attack.
+ */
+export async function isSafeRemoteUrl(raw: string): Promise<boolean> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  const host = url.hostname.replace(/^\[|\]$/g, ""); // IPv6 literals arrive bracketed
+  if (net.isIP(host)) return isPublicAddress(host);
+  let addresses: { address: string }[];
+  try {
+    addresses = await lookup(host, { all: true, verbatim: true });
+  } catch {
+    return false; // unresolvable: nothing to probe
+  }
+  return addresses.length > 0 && addresses.every((a) => isPublicAddress(a.address));
+}
+
+export function metaFromHeaders(h: Headers, ranged: boolean): RemotePdfMeta {
+  let contentLength = h.get("content-length") ?? "";
+  if (ranged) {
+    // A 206's Content-Length is the range size, not the file size; the total
+    // rides along in Content-Range ("bytes 0-0/48213").
+    const total = h.get("content-range")?.split("/")[1];
+    if (total && /^\d+$/.test(total)) contentLength = total;
+  }
+  return {
+    etag: h.get("etag") ?? "",
+    lastModified: h.get("last-modified") ?? "",
+    contentLength,
+  };
+}
+
+/** One request, following redirects by hand and re-validating each hop. */
+async function probe(startUrl: string, method: "HEAD" | "GET"): Promise<Response | null> {
+  let url = startUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    if (!(await isSafeRemoteUrl(url))) return null;
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method,
+        ...(method === "GET" ? { headers: { Range: "bytes=0-0" } } : {}),
+        redirect: "manual",
+        signal: AbortSignal.timeout(REMOTE_PROBE_TIMEOUT_MS),
+      });
+    } catch {
+      return null;
+    }
+    // Release the (at most one-byte) body so the connection is not held open.
+    try {
+      await res.body?.cancel();
+    } catch {
+      // Already consumed or not cancelable — nothing to do.
+    }
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location");
+      if (!location) return null;
+      try {
+        url = new URL(location, url).toString();
+      } catch {
+        return null;
+      }
+      continue;
+    }
+    return res;
+  }
+  return null; // redirect loop or an unreasonably long chain
+}
+
+let inFlight = 0;
+
+/**
+ * Probe a remote PDF for its validator headers without downloading it: a HEAD
+ * first, falling back to a one-byte ranged GET for hosts that reject HEAD.
+ * Returns null when the URL is unsafe to fetch, the host is unreachable or
+ * errors, or too many probes are already running — callers degrade to "no
+ * change detection" rather than surfacing a failure.
+ */
+export async function fetchRemotePdfMeta(url: string): Promise<RemotePdfMeta | null> {
+  if (inFlight >= MAX_CONCURRENT_PROBES) return null;
+  inFlight++;
+  try {
+    const head = await probe(url, "HEAD");
+    if (head?.ok) return metaFromHeaders(head.headers, false);
+    // Some hosts and CDNs only route GET; retry with a ranged request.
+    const get = await probe(url, "GET");
+    if (get?.ok) return metaFromHeaders(get.headers, true);
+    return null;
+  } finally {
+    inFlight--;
+  }
+}

--- a/server/remoteDeck.test.ts
+++ b/server/remoteDeck.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import type { Server } from "socket.io";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { FakeSupabase, type SessionRow } from "./test/fakeSupabase.js";
+
+// The routes' job is auth, shape and bookkeeping; whether the remote host is
+// reachable is lib/remotePdf's, and it has its own tests. Stub the probe so a
+// route test never touches DNS or the network.
+const probe = vi.fn<(url: string) => Promise<unknown>>();
+vi.mock("./lib/remotePdf.js", () => ({
+  fetchRemotePdfMeta: (url: string) => probe(url),
+}));
+
+const { createApp } = await import("./app.js");
+
+const emissions: { room: string; event: string; payload: unknown }[] = [];
+const fakeIo = {
+  in: () => ({ fetchSockets: async () => [] }),
+  to: (room: string) => ({
+    emit: (event: string, payload?: unknown) => emissions.push({ room, event, payload }),
+  }),
+} as unknown as Server;
+
+const appWith = (fake: FakeSupabase) =>
+  createApp({ supabase: fake as unknown as SupabaseClient, io: fakeIo });
+
+const future = () => new Date(Date.now() + 86_400_000).toISOString();
+
+/** A URL-backed presentation: no server copy, just a link to someone's PDF. */
+const urlRow = (over: Partial<SessionRow> = {}): SessionRow => ({
+  id: "ABC123",
+  pdf_path: "",
+  pdf_url: "https://cdn.example.com/deck.pdf",
+  filename: "Talk",
+  total_slides: 12,
+  current_slide: 3,
+  local: false,
+  controller_token: "secret-token",
+  passphrase: "PASS1234",
+  user_id: "user-1",
+  expires_at: future(),
+  ...over,
+});
+
+const validators = { etag: '"v1"', lastModified: "", contentLength: "900" };
+
+beforeEach(() => {
+  emissions.length = 0;
+  probe.mockReset();
+  probe.mockResolvedValue(validators);
+});
+
+describe("GET /api/sessions/:id/remote-version", () => {
+  it("returns the remote validators to the controller", async () => {
+    const res = await request(appWith(new FakeSupabase([urlRow()])))
+      .get("/api/sessions/ABC123/remote-version")
+      .set("x-controller-token", "secret-token");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(validators);
+    expect(probe).toHaveBeenCalledWith("https://cdn.example.com/deck.pdf");
+  });
+
+  it("authorizes the logged-in owner by bearer token too", async () => {
+    const fake = new FakeSupabase([urlRow()]).addToken("tok", "user-1");
+    const res = await request(appWith(fake))
+      .get("/api/sessions/ABC123/remote-version")
+      .set("Authorization", "Bearer tok");
+    expect(res.status).toBe(200);
+  });
+
+  it("403s on a wrong controller token, and never probes the host", async () => {
+    const res = await request(appWith(new FakeSupabase([urlRow()])))
+      .get("/api/sessions/ABC123/remote-version")
+      .set("x-controller-token", "wrong");
+    expect(res.status).toBe(403);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("403s for a signed-in user who doesn't own the presentation", async () => {
+    const fake = new FakeSupabase([urlRow()]).addToken("tok", "someone-else");
+    const res = await request(appWith(fake))
+      .get("/api/sessions/ABC123/remote-version")
+      .set("Authorization", "Bearer tok");
+    expect(res.status).toBe(403);
+  });
+
+  it("404s for a deck that isn't URL-backed — nothing to watch", async () => {
+    const hosted = urlRow({ pdf_url: "", pdf_path: "ABC123.pdf" });
+    const res = await request(appWith(new FakeSupabase([hosted])))
+      .get("/api/sessions/ABC123/remote-version")
+      .set("x-controller-token", "secret-token");
+    expect(res.status).toBe(404);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("404s for a local deck", async () => {
+    const res = await request(appWith(new FakeSupabase([urlRow({ local: true })])))
+      .get("/api/sessions/ABC123/remote-version")
+      .set("x-controller-token", "secret-token");
+    expect(res.status).toBe(404);
+  });
+
+  it("404s for an unknown or expired session", async () => {
+    const unknown = await request(appWith(new FakeSupabase([])))
+      .get("/api/sessions/NOPE00/remote-version")
+      .set("x-controller-token", "secret-token");
+    expect(unknown.status).toBe(404);
+
+    const expired = await request(appWith(new FakeSupabase([urlRow({ status: "expired" })])))
+      .get("/api/sessions/ABC123/remote-version")
+      .set("x-controller-token", "secret-token");
+    expect(expired.status).toBe(404);
+  });
+
+  it("502s when the host can't be reached or is refused", async () => {
+    probe.mockResolvedValue(null);
+    const res = await request(appWith(new FakeSupabase([urlRow()])))
+      .get("/api/sessions/ABC123/remote-version")
+      .set("x-controller-token", "secret-token");
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("POST /api/sessions/:id/deck-refreshed", () => {
+  const post = (fake: FakeSupabase, body: unknown, token = "secret-token") =>
+    request(appWith(fake))
+      .post("/api/sessions/ABC123/deck-refreshed")
+      .set("x-controller-token", token)
+      .send(body as object);
+
+  it("records the new page count and tells the room to reload", async () => {
+    const fake = new FakeSupabase([urlRow()]);
+    const res = await post(fake, { total_slides: 20 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, totalSlides: 20, filename: "Talk" });
+    expect(fake.rows[0].total_slides).toBe(20);
+    expect(emissions).toContainEqual({
+      room: "ABC123",
+      event: "deck_updated",
+      payload: { filename: "Talk", totalSlides: 20 },
+    });
+  });
+
+  it("clamps a current slide that the shorter deck no longer has", async () => {
+    const fake = new FakeSupabase([urlRow({ current_slide: 9 })]);
+    const res = await post(fake, { total_slides: 7 });
+    expect(res.status).toBe(200);
+    expect(fake.rows[0].current_slide).toBe(7);
+  });
+
+  it("leaves an in-range current slide alone", async () => {
+    const fake = new FakeSupabase([urlRow({ current_slide: 3 })]);
+    await post(fake, { total_slides: 20 });
+    expect(fake.rows[0].current_slide).toBe(3);
+  });
+
+  it("uploads nothing — a URL-backed deck keeps no server copy", async () => {
+    const fake = new FakeSupabase([urlRow()]);
+    await post(fake, { total_slides: 20 });
+    expect(fake.uploaded.size).toBe(0);
+  });
+
+  it("400s on a missing, unparseable or out-of-range total_slides", async () => {
+    for (const body of [{}, { total_slides: "lots" }, { total_slides: 0 }, { total_slides: 99999 }]) {
+      const fake = new FakeSupabase([urlRow()]);
+      const res = await post(fake, body);
+      expect(res.status, JSON.stringify(body)).toBe(400);
+      expect(fake.rows[0].total_slides).toBe(12); // untouched
+    }
+  });
+
+  it("400s for a deck that isn't URL-backed", async () => {
+    const fake = new FakeSupabase([urlRow({ pdf_url: "", pdf_path: "ABC123.pdf" })]);
+    const res = await post(fake, { total_slides: 20 });
+    expect(res.status).toBe(400);
+    expect(emissions).toHaveLength(0);
+  });
+
+  it("403s on a wrong controller token and changes nothing", async () => {
+    const fake = new FakeSupabase([urlRow()]);
+    const res = await post(fake, { total_slides: 20 }, "wrong");
+    expect(res.status).toBe(403);
+    expect(fake.rows[0].total_slides).toBe(12);
+    expect(emissions).toHaveLength(0);
+  });
+
+  it("404s for an unknown session", async () => {
+    const res = await request(appWith(new FakeSupabase([])))
+      .post("/api/sessions/NOPE00/deck-refreshed")
+      .set("x-controller-token", "secret-token")
+      .send({ total_slides: 20 });
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -36,6 +36,67 @@ function singleField(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
+// --- URL-backed deck republish detection ---
+
+// Cheap change-detection metadata for a remote PDF: the host's validator
+// headers, as available. Opaque strings only — the body is never downloaded.
+interface RemotePdfMeta {
+  etag: string;
+  lastModified: string;
+  contentLength: string;
+}
+
+const REMOTE_PROBE_TIMEOUT_MS = 10_000;
+
+function metaFromHeaders(h: Headers, ranged: boolean): RemotePdfMeta {
+  let contentLength = h.get("content-length") ?? "";
+  if (ranged) {
+    // A 206's Content-Length is the range size, not the file size; the total
+    // rides along in Content-Range ("bytes 0-0/48213").
+    const total = h.get("content-range")?.split("/")[1];
+    if (total && /^\d+$/.test(total)) contentLength = total;
+  }
+  return {
+    etag: h.get("etag") ?? "",
+    lastModified: h.get("last-modified") ?? "",
+    contentLength,
+  };
+}
+
+/**
+ * Probe a remote PDF for its validator headers without downloading it: a HEAD
+ * first, falling back to a one-byte ranged GET for hosts that reject HEAD.
+ * Returns null when the host is unreachable or errors — callers degrade to
+ * "no change detection" rather than surfacing a failure.
+ */
+async function fetchRemotePdfMeta(url: string): Promise<RemotePdfMeta | null> {
+  const probe = async (method: "HEAD" | "GET"): Promise<Response> => {
+    const res = await fetch(url, {
+      method,
+      ...(method === "GET" ? { headers: { Range: "bytes=0-0" } } : {}),
+      redirect: "follow",
+      signal: AbortSignal.timeout(REMOTE_PROBE_TIMEOUT_MS),
+    });
+    // Release the (at most one-byte) body so the connection is not held open.
+    try {
+      await res.body?.cancel();
+    } catch {
+      // Already consumed or not cancelable — nothing to do.
+    }
+    return res;
+  };
+  try {
+    const head = await probe("HEAD");
+    if (head.ok) return metaFromHeaders(head.headers, false);
+    // Some hosts and CDNs only route GET; retry with a ranged request.
+    const get = await probe("GET");
+    if (get.ok) return metaFromHeaders(get.headers, true);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export function registerSessionRoutes(app: express.Express, { supabase, io, socketState }: RouteDeps) {
   const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 50 * 1024 * 1024 } });
 
@@ -619,6 +680,117 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
     }
   });
 
+  // GET /api/sessions/:id/remote-version — cheap republish detection for a
+  // URL-backed deck. Answers with the remote PDF's validator tuple (ETag /
+  // Last-Modified / Content-Length, as available) so the controller can tell,
+  // without downloading anything, whether the file at `pdf_url` has changed
+  // since the previous poll. Authorized like the /pdf route (controller token
+  // or the logged-in owner): the values themselves are opaque strings, but
+  // there is no reason to let arbitrary visitors probe them.
+  //
+  //   - 404 when the session is unknown/expired or not URL-backed (local and
+  //     server-hosted decks have no pdf_url) — the client reads this as
+  //     "nothing to watch" and stops polling.
+  //   - 502 when the remote host is unreachable or errors — the client backs
+  //     off and keeps today's behaviour; nothing surfaces to the presenter.
+  app.get("/api/sessions/:id/remote-version", async (req, res) => {
+    try {
+      const user = isLocalMode ? null : await resolveOptionalUserId(supabase, req);
+
+      const { data: row, error: rowError } = await supabase
+        .from("sessions")
+        .select("id, local, pdf_url, user_id, controller_token")
+        .eq("id", req.params.id)
+        .neq("status", "expired")
+        .single();
+      if (rowError || !row) {
+        res.status(404).json({ error: "Session not found" });
+        return;
+      }
+      const authorized =
+        safeEqual(req.get("x-controller-token") || "", row.controller_token) ||
+        (!isLocalMode && !!user && row.user_id === user);
+      if (!authorized) {
+        res.status(403).json({ error: "Not authorized" });
+        return;
+      }
+      if (row.local || !row.pdf_url) {
+        res.status(404).json({ error: "This presentation is not backed by an external URL" });
+        return;
+      }
+
+      const meta = await fetchRemotePdfMeta(row.pdf_url);
+      if (!meta) {
+        res.status(502).json({ error: "The remote host could not be reached" });
+        return;
+      }
+      res.json(meta);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // POST /api/sessions/:id/deck-refreshed — the controller noticed (via
+  // remote-version polling) that a URL-backed deck was republished at its
+  // source and the presenter accepted the new version. Unlike /pdf there are
+  // no bytes to store — pdf_url decks keep no server copy — so this only
+  // records the new page count, clamps the current slide into range, drops
+  // the stored drawings (keyed by slide number) and announces the swap to the
+  // room; every client re-fetches the URL itself. The filename is unchanged:
+  // a republish replaces the content, not the presentation's title.
+  app.post("/api/sessions/:id/deck-refreshed", async (req, res) => {
+    try {
+      const user = isLocalMode ? null : await resolveOptionalUserId(supabase, req);
+
+      const totalSlides = parseInt(req.body.total_slides, 10);
+      if (!isValidTotalSlides(totalSlides)) {
+        res.status(400).json({ error: "A valid total_slides is required" });
+        return;
+      }
+
+      const { data: row, error: rowError } = await supabase
+        .from("sessions")
+        .select("id, local, pdf_url, user_id, controller_token, filename, current_slide")
+        .eq("id", req.params.id)
+        .neq("status", "expired")
+        .single();
+      if (rowError || !row) {
+        res.status(404).json({ error: "Session not found" });
+        return;
+      }
+      const authorized =
+        safeEqual(req.get("x-controller-token") || "", row.controller_token) ||
+        (!isLocalMode && !!user && row.user_id === user);
+      if (!authorized) {
+        res.status(403).json({ error: "Not authorized" });
+        return;
+      }
+      if (row.local || !row.pdf_url) {
+        res.status(400).json({ error: "This presentation is not backed by an external URL" });
+        return;
+      }
+
+      const clampedSlide = Math.min(Math.max(row.current_slide ?? 1, 1), totalSlides);
+      const { error: updateError } = await supabase
+        .from("sessions")
+        .update({ total_slides: totalSlides, current_slide: clampedSlide })
+        .eq("id", row.id);
+      if (updateError) {
+        res.status(500).json({ error: "Failed to update session" });
+        return;
+      }
+
+      socketState?.annotations.delete(String(req.params.id));
+      io.to(req.params.id).emit("deck_updated", { filename: row.filename, totalSlides });
+
+      res.json({ ok: true, totalSlides, filename: row.filename });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
   app.get("/api/sessions/:id", async (req, res) => {
     const { data, error } = await supabase
       .from("sessions")
@@ -652,6 +824,11 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
       current_slide: data.current_slide,
       local: data.local,
       pdfUrl,
+      // Whether pdfUrl points at someone else's host rather than our storage.
+      // The client needs this to re-fetch a changed deck correctly: our own
+      // object URLs take a cache-busting query parameter, but an external one
+      // may be presigned, where an extra parameter invalidates the signature.
+      external: !!data.pdf_url,
     });
   });
 

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -9,6 +9,7 @@ import { getBearerToken, requireUser, resolveOptionalUserId, safeEqual } from ".
 import { isLocalMode } from "../local/mode.js";
 import { clearSessionState, type SocketState } from "../socket.js";
 import { baseUrl } from "../lib/baseUrl.js";
+import { fetchRemotePdfMeta } from "../lib/remotePdf.js";
 import { createPresentHandoff, handoffTokenFrom, updatePresentDeck } from "../lib/presentHandoff.js";
 import { generatePassphrase, insertSession, ownedExpiry } from "../lib/sessionRows.js";
 
@@ -34,67 +35,6 @@ export const MAX_CONCURRENT_PRESENTATIONS = 3;
 function singleField(value: unknown): string | null {
   if (value === undefined) return "";
   return typeof value === "string" ? value : null;
-}
-
-// --- URL-backed deck republish detection ---
-
-// Cheap change-detection metadata for a remote PDF: the host's validator
-// headers, as available. Opaque strings only — the body is never downloaded.
-interface RemotePdfMeta {
-  etag: string;
-  lastModified: string;
-  contentLength: string;
-}
-
-const REMOTE_PROBE_TIMEOUT_MS = 10_000;
-
-function metaFromHeaders(h: Headers, ranged: boolean): RemotePdfMeta {
-  let contentLength = h.get("content-length") ?? "";
-  if (ranged) {
-    // A 206's Content-Length is the range size, not the file size; the total
-    // rides along in Content-Range ("bytes 0-0/48213").
-    const total = h.get("content-range")?.split("/")[1];
-    if (total && /^\d+$/.test(total)) contentLength = total;
-  }
-  return {
-    etag: h.get("etag") ?? "",
-    lastModified: h.get("last-modified") ?? "",
-    contentLength,
-  };
-}
-
-/**
- * Probe a remote PDF for its validator headers without downloading it: a HEAD
- * first, falling back to a one-byte ranged GET for hosts that reject HEAD.
- * Returns null when the host is unreachable or errors — callers degrade to
- * "no change detection" rather than surfacing a failure.
- */
-async function fetchRemotePdfMeta(url: string): Promise<RemotePdfMeta | null> {
-  const probe = async (method: "HEAD" | "GET"): Promise<Response> => {
-    const res = await fetch(url, {
-      method,
-      ...(method === "GET" ? { headers: { Range: "bytes=0-0" } } : {}),
-      redirect: "follow",
-      signal: AbortSignal.timeout(REMOTE_PROBE_TIMEOUT_MS),
-    });
-    // Release the (at most one-byte) body so the connection is not held open.
-    try {
-      await res.body?.cancel();
-    } catch {
-      // Already consumed or not cancelable — nothing to do.
-    }
-    return res;
-  };
-  try {
-    const head = await probe("HEAD");
-    if (head.ok) return metaFromHeaders(head.headers, false);
-    // Some hosts and CDNs only route GET; retry with a ranged request.
-    const get = await probe("GET");
-    if (get.ok) return metaFromHeaders(get.headers, true);
-    return null;
-  } catch {
-    return null;
-  }
 }
 
 export function registerSessionRoutes(app: express.Express, { supabase, io, socketState }: RouteDeps) {
@@ -739,6 +679,13 @@ export function registerSessionRoutes(app: express.Express, { supabase, io, sock
   // the stored drawings (keyed by slide number) and announces the swap to the
   // room; every client re-fetches the URL itself. The filename is unchanged:
   // a republish replaces the content, not the presentation's title.
+  //
+  // Unlike /pdf, the page count is asserted by the client rather than parsed
+  // here — there are no bytes on this side to count. That is safe because only
+  // the controller can call this, and because isValidTotalSlides bounds the
+  // value: total_slides scales the per-session annotation caps and gates slide
+  // numbers, so an unbounded one would be a memory lever, but a wrong-but-bounded
+  // one only mis-clamps the presenter's own deck until the next real update.
   app.post("/api/sessions/:id/deck-refreshed", async (req, res) => {
     try {
       const user = isLocalMode ? null : await resolveOptionalUserId(supabase, req);

--- a/server/validation.ts
+++ b/server/validation.ts
@@ -1,9 +1,15 @@
 // Pure validation/sanitization helpers, factored out of the request/socket
 // handlers so they can be unit-tested without a server or Supabase.
 
-// Validate a user-supplied external PDF URL. We only ever hand this back to the
-// client to fetch (the server never requests it), so the bar is simply that it
-// be a well-formed https URL — rejecting http:/data:/javascript: and garbage.
+// Validate a user-supplied external PDF URL. This is a syntactic check only —
+// scheme and shape — and deliberately says nothing about where the URL points.
+//
+// The value is mainly handed back to the client to fetch. It is also probed by
+// the server for change detection (GET /api/sessions/:id/remote-version), and
+// that path must NOT rely on this function for safety: dereferencing a
+// visitor-supplied URL needs address-level checks, which live in
+// lib/remotePdf.ts (isSafeRemoteUrl). Anything new that fetches a pdf_url
+// server-side belongs behind that helper too.
 export function isValidHttpsUrl(value: unknown): value is string {
   if (typeof value !== "string" || !value) return false;
   try {


### PR DESCRIPTION
Closes #20. Stacked on #72 → #71 → #70 — retargets as each merges.

## What
- `GET /api/sessions/:id/remote-version`: 404 unless the row has a `pdf_url`; server-side `HEAD` (fallback: one-byte ranged `GET`) returns the opaque `{ etag, lastModified, contentLength }` signature — metadata only, body never downloaded. Auth mirrors the existing session routes (controller/owner).
- Controller-only poller (one per session, never per viewer) for non-local, URL-backed decks: 30s base doubling to a 4-minute cap, reset on change, paused while `document.hidden`, stops on `session_ended`/unmount. Missing validators, 403/404 or fetch failure → stop silently; behaviour reverts to today's with nothing surfaced to the presenter.
- CDN-safe: a signature change must hold steady across two consecutive polls before it's believed. First sighting is always baseline.
- Apply reuses the house rule from #21 — no auto-swap under a live presenter. A parallel **Deck updated** pill (same cluster/styling) appears; presenter clicks → new `POST /api/sessions/:id/deck-refreshed` (controller-token auth, same validation model as `/pdf`) updates `total_slides`, clamps `current_slide`, clears stored annotations and emits `deck_updated`. **No bytes are uploaded** — `pdf_url` decks have none. Everyone, the clicking controller included, reloads via the existing socket `deck_updated` path. Both routes documented in api.md + openapi.

## Decisions / assumptions
- The controller relies on the socket echo of `deck_updated` rather than calling `applyDeckUpdate` locally — mirrors `replacePdf`'s synced path and avoids a duplicate PDF download.
- The server, not a client URL heuristic, decides "nothing to watch": non-URL-backed decks make exactly one `remote-version` request, get 404, and stop.
- Auto-apply on the prep screen (optional) not implemented.
- Note: `validation.ts`'s comment that the server never requests the external URL is now only true of the body — the server probes validators (https-only URLs, controller/owner auth, opaque strings only).

## Verification
Client: `tsc -b`, `eslint`, vitest 30/30. Server: vitest 45/45 + live smoke test (auth 403s, 404 for non-URL decks, single-HEAD probe, 502 on unreachable host, slide clamp 9→7, `deck_updated` broadcast).