### PR TITLE
Reload the controller's deck when a shared session's PDF is replaced (#77)

### DIFF
--- a/client/src/pages/Presentation.tsx
+++ b/client/src/pages/Presentation.tsx
@@ -253,14 +253,27 @@ export default function Presentation() {
     setAnnotations((prev) => (prev[slide]?.length ? { ...prev, [slide]: [] } : prev));
   }, []);
 
-  // Swap in a replacement deck that arrived over the wire — socket
-  // `deck_updated` for synced sessions or a BroadcastChannel `deck_update`
-  // for local ones. Drawings are dropped wholesale: they are keyed by slide
-  // number and the new document renumbers every slide after an insertion.
-  // Slide clamping needs no extra work here: the deckInfo effect adopts the
-  // new document's page count once it loads.
+  // The deck swap currently being loaded, if any. A replacement uploaded from
+  // this window is announced to it twice — by the upload's own response and by
+  // the server's `deck_updated` broadcast, the one every viewer acts on — and
+  // both describe the same document. Keyed on that description so whichever
+  // announcement lands first starts the swap and the other joins it rather
+  // than downloading the same deck a second time. Cleared once the swap
+  // settles, so a later announcement is never mistaken for this one.
+  const deckSwapRef = useRef<{ key: string; done: Promise<void> } | null>(null);
+
+  // Swap in a replacement deck: announced over the wire (socket `deck_updated`
+  // for synced sessions, a BroadcastChannel `deck_update` for local ones) or by
+  // the reply to this window's own replace. Drawings are dropped wholesale:
+  // they are keyed by slide number and the new document renumbers every slide
+  // after an insertion. Slide clamping needs no extra work here: the deckInfo
+  // effect adopts the new document's page count once it loads.
   const applyDeckUpdate = useCallback(
-    ({ filename, totalSlides }: { filename: string; totalSlides: number }) => {
+    ({ filename, totalSlides }: { filename: string; totalSlides: number }): Promise<void> => {
+      const key = `${totalSlides}:${filename}`;
+      const inFlight = deckSwapRef.current;
+      if (inFlight?.key === key) return inFlight.done;
+
       setFilename(filename);
       setAnnotations({});
       lsRemove(annotationsKey(id!));
@@ -268,7 +281,7 @@ export default function Presentation() {
       setNotesEdited(false);
       setTotalSlides(totalSlides);
       setCurrentSlide((slide) => Math.min(Math.max(slide, 1), totalSlides));
-      (async () => {
+      const done = (async () => {
         try {
           if (local) {
             // Same-browser windows read the fresh record straight from IndexedDB.
@@ -305,6 +318,11 @@ export default function Presentation() {
           // stored row already describes the new one and a reload recovers.
         }
       })();
+      deckSwapRef.current = { key, done };
+      void done.finally(() => {
+        if (deckSwapRef.current?.done === done) deckSwapRef.current = null;
+      });
+      return done;
     },
     [local, id]
   );
@@ -424,7 +442,7 @@ export default function Presentation() {
       else if (type === "stroke_undo") applyUndo(payload.slide);
       else if (type === "annotations_clear") applyClear(payload.slide);
       else if (type === "annotations_state") setAnnotations(payload);
-      else if (type === "deck_update") applyDeckUpdate(payload);
+      else if (type === "deck_update") void applyDeckUpdate(payload);
       else if (type === "session_ended") navigate("/", { replace: true });
       else if (type === "state_request") {
         // Controller is the source of truth for a local session; reply so a
@@ -595,9 +613,11 @@ export default function Presentation() {
     });
 
     // The controller replaced the deck (server broadcast from the replace
-    // endpoint); reload the new document under the same session.
+    // endpoint); reload the new document under the same session. The window
+    // that performed the replace has usually applied it already, straight from
+    // the reply to its own upload — this then coalesces into that swap.
     socket.on("deck_updated", (payload: { filename: string; totalSlides: number }) => {
-      applyDeckUpdate(payload);
+      void applyDeckUpdate(payload);
     });
 
     // Another window took controllership (same token, e.g. a second tab).
@@ -1054,10 +1074,25 @@ export default function Presentation() {
           headers: authHeaders,
           body: form,
         });
+        const body = await res.json().catch(() => ({}));
         if (!res.ok) {
-          const body = await res.json().catch(() => ({}));
           throw new Error(body.error || "Failed to replace the PDF");
         }
+        // Swap the new deck in from this reply rather than waiting for the
+        // server's `deck_updated` broadcast to come back around to us. That
+        // broadcast is what moves the viewers, and it usually moves this
+        // window too — but it is a single fire-and-forget message to the one
+        // socket that just spent the upload saturating its connection, and a
+        // missed one has no recovery: nothing re-announces a deck, so the
+        // presenter stayed on the old slides until a manual reload while every
+        // viewer had already moved on. Applying here needs no socket at all,
+        // and the broadcast, when it does arrive, joins this same swap.
+        await applyDeckUpdate({
+          // The server's spelling of both, so the broadcast describing this
+          // replace produces the identical key and coalesces with it.
+          filename: typeof body.filename === "string" && body.filename ? body.filename : filename,
+          totalSlides: typeof body.totalSlides === "number" ? body.totalSlides : totalSlides,
+        });
       }
 
       track("deck-replace", {


### PR DESCRIPTION
## The problem

Replacing a shared session's PDF (drag-and-drop onto the deck name in the controller header) moved every viewer to the new deck, but the presenter's own window sometimes stayed on the old one until a manual reload.

## Root cause

The controller learned about its *own* replace only from the server's `deck_updated` broadcast. `replacePdf` uploaded the file and then did nothing locally — it waited for the socket message to come back around, the same message the viewers act on.

That message is a single fire-and-forget emit to the one socket that just spent the upload saturating its connection, and there is no recovery if it is missed: nothing ever re-announces a deck. A rejoin doesn't help either — `session_state` carries `currentSlide` / `totalSlides` / `role` / `annotations` and no deck identity at all, so a controller that misses the broadcast has no way to notice the document changed. Viewers are unaffected because they aren't the ones uploading. Hence: viewers correct, controller stale, intermittent, and a refresh fixes it.

Verified against a `PRESIO_MODE=local` API: with the controller's socket out of the room at the instant of the replace, the viewer receives `deck_updated` and the controller receives nothing — and the rejoin's `session_state` still says nothing about the deck.

## The fix

The controller now applies the swap from the reply to its own upload, through the existing `applyDeckUpdate` path (the same one the viewers' `deck_updated` uses, and the one the local/unshared replace already used directly). Nothing new was invented, and the local path is untouched.

Because that makes the replace announced twice to the uploading window, `applyDeckUpdate` keys the swap it is loading on `totalSlides:filename` and returns the in-flight promise for a repeat — so whichever announcement arrives first does the work and the other joins it instead of downloading the same deck again.

**On the intermittency:** this is an ordering fix, not a delay. The controller no longer depends on the broadcast at all — it applies from a reply it is already awaiting — so there is no window in which the message can be lost. The coalescing key comes from the server's own response fields, which are byte-identical to what it broadcasts (confirmed end to end), so the two announcements always collapse into one swap. If they were ever to land far enough apart to miss each other, the result is still correct — just one redundant fetch — so the dedupe can never suppress a real update.

Correctness details on this path: the current slide is still clamped into range and otherwise preserved across the swap; the local branch still revokes the superseded object URL before replacing it; `await onReplacePdf(...)` in `ControllerView` now genuinely waits for the new document, so the "Replacing…" state ends when the deck is actually on screen.

## Ruled out

- **Stale cache-busting / old bytes from storage.** `applyDeckUpdate` re-fetches with a fresh `?v=`, and a cache-busted GET issued the moment the upload response returns already serves the new bytes.
- **The controller not being in the socket room.** It joins the room like any viewer, and `io.to(id).emit` includes it — when it is connected, it does receive `deck_updated`.
- **A pdf.js document/proxy that isn't reloaded.** `setPdf` swaps document identity, and the page cache invalidates on it; both the main canvas effect and the deck-info effect re-run on the new document.
- **A missing effect dependency.** The `deck_updated` subscription and `applyDeckUpdate` are stable for the life of a synced session.

## Verified

- `client`: `npm run build` (tsc -b + vite build) clean, `npm test` 88/88 green, `npm run lint` unchanged (14 pre-existing errors on `main`, same 14 after — none in the changed code).
- `server`: `npm test` 103/103 green.
- End to end against `PRESIO_MODE=local`: create → claim → join controller + viewer → replace. The response `{ ok, totalSlides, filename }` matches the `deck_updated` payload exactly (so the coalescing key matches), and the failure mode reproduces with the controller's socket briefly out of the room.

Not verified in a browser — the swap on screen still wants a manual check with a real controller and a viewer window.

## Note

The "Deck updated" pill for URL-backed decks (`applyRemoteDeckUpdate`, #20) waits on the same broadcast in the same way and has the same exposure; left alone here to keep this change to the reported path.

PR #79 (`feat/issue-75-offline-import`) is open against `main` and touches `ControllerView`/`Presentation.tsx` too, so whichever merges second may need a rebase.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
