### PR TITLE
Precache the built assets so a fresh install works offline

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -3,10 +3,33 @@
 // already live in IndexedDB). Deliberately conservative — API calls and
 // websockets are never intercepted, and the shell is refreshed network-first
 // so deploys are picked up on the next load.
-const CACHE = "presio-shell-v1";
+//
+// The build rewrites the two placeholders below with the real asset list and a
+// content-derived id (see `presio-sw-precache` in vite.config.ts). Precaching
+// on install rather than on demand is what makes a first-run install usable
+// offline: the pdf.js worker is a lazily fetched chunk, so an install-then-go-
+// offline would otherwise open the app fine and fail on the first PDF.
+const BUILD_ID = "__BUILD_ID__";
+const PRECACHE = "__PRECACHE_MANIFEST__";
 
-self.addEventListener("install", () => {
-  self.skipWaiting();
+// Unreplaced (an unbuilt copy) degrades to the old fetch-time caching.
+const PRECACHE_URLS = Array.isArray(PRECACHE) ? PRECACHE : [];
+const CACHE = `presio-shell-${BUILD_ID}`;
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE).then(async (cache) => {
+      // One entry at a time: `cache.addAll` is all-or-nothing, and a single
+      // 404 would fail the install and leave the app with no offline support
+      // at all rather than a partial cache.
+      await Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache.add(new Request(url, { cache: "reload" })).catch(() => {})
+        )
+      );
+      await self.skipWaiting();
+    })
+  );
 });
 
 self.addEventListener("activate", (event) => {
@@ -54,5 +77,12 @@ self.addEventListener("fetch", (event) => {
         }
       })
     );
+    return;
   }
+
+  // Everything else that was precached (icons, the web manifest): serve it
+  // from the cache when the network is gone.
+  event.respondWith(
+    fetch(request).catch(async () => (await caches.match(request)) || Response.error())
+  );
 });

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,10 +1,60 @@
 /// <reference types="vitest/config" />
+import crypto from "crypto"
+import fs from "fs"
 import path from "path"
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// Bake the built asset list into the shipped service worker so a fresh install
+// precaches the whole app up front. The pdf.js worker and its wasm helper are
+// separate chunks that aren't fetched until the first PDF renders, so caching
+// on demand leaves an installed-then-offline app unable to open a deck.
+function precacheServiceWorker(): Plugin {
+  let outDir = ""
+  return {
+    name: "presio-sw-precache",
+    apply: "build",
+    configResolved(config) {
+      outDir = path.resolve(config.root, config.build.outDir)
+    },
+    closeBundle() {
+      const swPath = path.join(outDir, "sw.js")
+      if (!fs.existsSync(swPath)) return
+
+      const walk = (dir: string): string[] =>
+        fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+          const full = path.join(dir, entry.name)
+          return entry.isDirectory() ? walk(full) : [full]
+        })
+
+      // "/" stands in for index.html, which is what a navigation asks for and
+      // what the fetch handler falls back to.
+      const assets = walk(outDir)
+        .map((file) => "/" + path.relative(outDir, file).split(path.sep).join("/"))
+        .filter((url) => url !== "/sw.js" && url !== "/index.html")
+        .sort()
+      const manifest = ["/", ...assets]
+
+      // Content-derived so a deploy that changes nothing keeps its cache, and
+      // any real change makes a new one that `activate` sweeps the old into.
+      const buildId = crypto
+        .createHash("sha256")
+        .update(manifest.join("\n"))
+        .update(fs.readFileSync(path.join(outDir, "index.html")))
+        .digest("hex")
+        .slice(0, 12)
+
+      const sw = fs
+        .readFileSync(swPath, "utf8")
+        .replace('"__BUILD_ID__"', JSON.stringify(buildId))
+        .replace('"__PRECACHE_MANIFEST__"', JSON.stringify(manifest))
+      fs.writeFileSync(swPath, sw)
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), precacheServiceWorker()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## The bug

Install the PWA, load it once, turn off the network, drop in a PDF — the app opens but rendering fails with a dynamic-import error. Reported after testing #79.

The service worker only cached assets **as they were requested**. There was no precache on install, so a first run cached just what the initial page load happened to fetch:

| Asset | Size | When it loads | Cached on first run? |
|---|---|---|---|
| `index-*.js` | 5.3 MB | at boot | yes |
| `index-*.css` | 78 KB | at boot | yes |
| `pdf.worker-*.mjs` | 2.1 MB | first PDF render | **no** |
| `wasm-*.js` | 622 KB | on demand | **no** |
| `CheckerPage-*.js` | 26 KB | lazy route | **no** |

`client/src/lib/pdf.ts` imports the pdf.js worker with `?url`, so it is a separate chunk that is not fetched until the first page renders. Install, go offline, present — the fetch fails and there is nothing in the cache to fall back to.

A second gap: the navigation that registers the service worker is not intercepted (no controller yet), so `/` was only cached on the *second* load. An install-then-immediately-offline could fail to open the shell at all.

## The change

A small build plugin (`presio-sw-precache` in `client/vite.config.ts`) walks the emitted `dist` tree and rewrites two placeholders in `client/public/sw.js` with the real asset list and a content-derived build id. On install the worker now precaches that list, including `/`.

- **No new dependency.** The hand-written worker stays; the plugin is ~30 lines and does not pull in `vite-plugin-pwa`/workbox.
- **Entries are cached one at a time**, not with `cache.addAll`. `addAll` is all-or-nothing, so a single 404 would fail the install and leave the app with *no* offline support rather than a partial cache.
- **`cache: "reload"`** on each request so the precache is not populated from a stale HTTP cache.
- **The cache name carries the build id**, derived from the sorted asset list plus `index.html`, so a deploy that changes nothing keeps its cache and any real change makes a new one that the existing `activate` sweep clears.
- **`skipWaiting` now waits for the precache** instead of firing immediately, so the worker cannot claim clients before it can serve them.
- A final fetch fallback serves precached non-asset shell files (icons, the web manifest) from cache when the network is gone.
- The API and socket paths are still never intercepted.

Unchanged behaviour if the placeholders are never substituted (an unbuilt copy of the file): `PRECACHE` stays a string, the guard yields an empty list, and the worker degrades to the previous fetch-time caching.

## Trade-off

A fresh install now downloads the full ~8.2 MB bundle up front rather than ~5.4 MB at boot and the rest on first use. That is the point — it is what makes the app usable offline — but it is a real change in install cost on a slow connection. The bulk is the 5.3 MB main chunk and the 2.1 MB pdf.js worker; splitting those is a separate piece of work (the build already warns about the main chunk size).

## Verified

- `npm run build` clean; the generated `dist/sw.js` parses and contains all five chunks including `pdf.worker` and `wasm`.
- Served `dist/` and requested **all 17 precache entries — 0 missing**, so nothing in the manifest silently 404s at install time.
- The build id is stable across repeated builds of identical output.
- Client tests 88/88. Lint reports the same 14 pre-existing errors as `main`, none in the touched files.

## Not verified

Not exercised in a real browser: the actual install → offline → present loop, and the upgrade path for an already-installed worker (`presio-shell-v1` should be swept by `activate` on first load of the new build). Worth testing on the preview with DevTools → Application → Service Workers, and with a hard "Update on reload" cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)